### PR TITLE
Use GPU radix sort when we can (based on AMD FidelityFX)

### DIFF
--- a/Assets/External/FfxParallelSort.meta
+++ b/Assets/External/FfxParallelSort.meta
@@ -1,0 +1,8 @@
+fileFormatVersion: 2
+guid: 0ed8b350220bfde4a95a42de51e4f885
+folderAsset: yes
+DefaultImporter:
+  externalObjects: {}
+  userData: 
+  assetBundleName: 
+  assetBundleVariant: 

--- a/Assets/External/FfxParallelSort/FfxParallelSort.compute
+++ b/Assets/External/FfxParallelSort/FfxParallelSort.compute
@@ -1,0 +1,566 @@
+// Originally based on FidelityFX SDK, Copyright © 2023 Advanced Micro Devices, Inc., MIT license
+// https://github.com/GPUOpen-Effects/FidelityFX-ParallelSort v1.1.1
+
+#pragma kernel FfxParallelSortReduce
+#pragma kernel FfxParallelSortScanAdd
+#pragma kernel FfxParallelSortScan
+#pragma kernel FfxParallelSortScatter
+#pragma kernel FfxParallelSortCount
+
+#pragma use_dxc
+#pragma require wavebasic
+
+// -------- Constant buffer data
+
+cbuffer cbParallelSort : register(b0)
+{
+    uint numKeys;
+    int  numBlocksPerThreadGroup;
+    uint numThreadGroups;
+    uint numThreadGroupsWithAdditionalBlocks;
+    uint numReduceThreadgroupPerBin;
+    uint numScanValues;
+    uint shift;
+    uint padding;
+};
+
+uint FfxNumKeys() { return numKeys; }
+int FfxNumBlocksPerThreadGroup() { return numBlocksPerThreadGroup; }
+uint FfxNumThreadGroups() { return numThreadGroups; }
+uint FfxNumThreadGroupsWithAdditionalBlocks() { return numThreadGroupsWithAdditionalBlocks; }
+uint FfxNumReduceThreadgroupPerBin() { return numReduceThreadgroupPerBin; }
+uint FfxNumScanValues() { return numScanValues; }
+uint FfxShiftBit() { return shift; }
+
+// -------- Read/Write buffers
+
+RWStructuredBuffer<uint> rw_source_keys;
+RWStructuredBuffer<uint> rw_dest_keys;
+RWStructuredBuffer<uint> rw_source_payloads;
+RWStructuredBuffer<uint> rw_dest_payloads;
+RWStructuredBuffer<uint> rw_sum_table;
+RWStructuredBuffer<uint> rw_reduce_table;
+RWStructuredBuffer<uint> rw_scan_source;
+RWStructuredBuffer<uint> rw_scan_dest;
+RWStructuredBuffer<uint> rw_scan_scratch;
+
+uint FfxLoadKey(uint index)
+{
+    return rw_source_keys[index];
+}
+void FfxStoreKey(uint index, uint value)
+{
+    rw_dest_keys[index] = value;
+}
+uint FfxLoadPayload(uint index)
+{
+    return rw_source_payloads[index];
+}
+void FfxStorePayload(uint index, uint value)
+{
+    rw_dest_payloads[index] = value;
+}
+uint FfxLoadSum(uint index)
+{
+    return rw_sum_table[index];
+}
+void FfxStoreSum(uint index, uint value)
+{
+    rw_sum_table[index] = value;
+}
+void FfxStoreReduce(uint index, uint value)
+{
+    rw_reduce_table[index] = value;
+}
+uint FfxLoadScanSource(uint index)
+{
+    return rw_scan_source[index];
+}
+void FfxStoreScanDest(uint index, uint value)
+{
+    rw_scan_dest[index] = value;
+}
+uint FfxLoadScanScratch(uint index)
+{
+    return rw_scan_scratch[index];
+}
+
+// -------- Compile-time constants
+
+// The number of bits we are sorting per pass. Changing this value requires internal changes in LDS distribution
+// and count, reduce, scan, and scatter passes
+#define FFX_PARALLELSORT_SORT_BITS_PER_PASS		    4
+
+// The number of bins used for the counting phase of the algorithm. Changing this value requires internal
+// changes in LDS distribution and count, reduce, scan, and scatter passes
+#define	FFX_PARALLELSORT_SORT_BIN_COUNT			    (1 << FFX_PARALLELSORT_SORT_BITS_PER_PASS)
+
+// The number of elements dealt with per running thread
+#define FFX_PARALLELSORT_ELEMENTS_PER_THREAD	    4
+
+// The number of threads to execute in parallel for each dispatch group
+#define FFX_PARALLELSORT_THREADGROUP_SIZE		    128
+
+
+// -------- Actual code
+
+groupshared uint gs_FFX_PARALLELSORT_Histogram[FFX_PARALLELSORT_THREADGROUP_SIZE * FFX_PARALLELSORT_SORT_BIN_COUNT];
+void ffxParallelSortCountUInt(uint localID, uint groupID, uint ShiftBit)
+{
+    // Start by clearing our local counts in LDS
+    for (int i = 0; i < FFX_PARALLELSORT_SORT_BIN_COUNT; i++)
+        gs_FFX_PARALLELSORT_Histogram[(i * FFX_PARALLELSORT_THREADGROUP_SIZE) + localID] = 0;
+
+    // Wait for everyone to catch up
+    GroupMemoryBarrierWithGroupSync();
+
+    // Data is processed in blocks, and how many we process can changed based on how much data we are processing
+    // versus how many thread groups we are processing with
+    int BlockSize = FFX_PARALLELSORT_ELEMENTS_PER_THREAD * FFX_PARALLELSORT_THREADGROUP_SIZE;
+
+    // Figure out this thread group's index into the block data (taking into account thread groups that need to do extra reads)
+    uint NumBlocksPerThreadGroup = FfxNumBlocksPerThreadGroup();
+    uint NumThreadGroups = FfxNumThreadGroups();
+    uint NumThreadGroupsWithAdditionalBlocks = FfxNumThreadGroupsWithAdditionalBlocks();
+    uint NumKeys = FfxNumKeys();
+
+    uint ThreadgroupBlockStart = (BlockSize * NumBlocksPerThreadGroup * groupID);
+    uint NumBlocksToProcess = NumBlocksPerThreadGroup;
+
+    if (groupID >= NumThreadGroups - NumThreadGroupsWithAdditionalBlocks)
+    {
+        ThreadgroupBlockStart += (groupID - (NumThreadGroups - NumThreadGroupsWithAdditionalBlocks)) * BlockSize;
+        NumBlocksToProcess++;
+    }
+
+    // Get the block start index for this thread
+    uint BlockIndex = ThreadgroupBlockStart + localID;
+
+    // Count value occurrence
+    for (uint BlockCount = 0; BlockCount < NumBlocksToProcess; BlockCount++, BlockIndex += BlockSize)
+    {
+        uint DataIndex = BlockIndex;
+
+        // Pre-load the key values in order to hide some of the read latency
+        uint srcKeys[FFX_PARALLELSORT_ELEMENTS_PER_THREAD];
+        srcKeys[0] = FfxLoadKey(DataIndex);
+        srcKeys[1] = FfxLoadKey(DataIndex + FFX_PARALLELSORT_THREADGROUP_SIZE);
+        srcKeys[2] = FfxLoadKey(DataIndex + (FFX_PARALLELSORT_THREADGROUP_SIZE * 2));
+        srcKeys[3] = FfxLoadKey(DataIndex + (FFX_PARALLELSORT_THREADGROUP_SIZE * 3));
+
+        for (uint i = 0; i < FFX_PARALLELSORT_ELEMENTS_PER_THREAD; i++)
+        {
+            if (DataIndex < NumKeys)
+            {
+                uint localKey = (srcKeys[i] >> ShiftBit) & 0xf;
+                InterlockedAdd(gs_FFX_PARALLELSORT_Histogram[(localKey * FFX_PARALLELSORT_THREADGROUP_SIZE) + localID], 1);
+                DataIndex += FFX_PARALLELSORT_THREADGROUP_SIZE;
+            }
+        }
+    }
+
+    // Even though our LDS layout guarantees no collisions, our thread group size is greater than a wave
+    // so we need to make sure all thread groups are done counting before we start tallying up the results
+    GroupMemoryBarrierWithGroupSync();
+
+    if (localID < FFX_PARALLELSORT_SORT_BIN_COUNT)
+    {
+        uint sum = 0;
+        for (int i = 0; i < FFX_PARALLELSORT_THREADGROUP_SIZE; i++)
+        {
+            sum += gs_FFX_PARALLELSORT_Histogram[localID * FFX_PARALLELSORT_THREADGROUP_SIZE + i];
+        }
+        FfxStoreSum(localID * NumThreadGroups + groupID, sum);
+    }
+}
+
+groupshared uint gs_FFX_PARALLELSORT_LDSSums[FFX_PARALLELSORT_THREADGROUP_SIZE];
+uint ffxParallelSortThreadgroupReduce(uint localSum, uint localID)
+{
+#if defined(SHADER_AVAILABLE_WAVEBASIC)
+    // Do wave local reduce
+    uint waveReduced = WaveActiveSum(localSum);
+
+    // First lane in a wave writes out wave reduction to LDS (this accounts for num waves per group greater than HW wave size)
+    // Note that some hardware with very small HW wave sizes (i.e. <= 8) may exhibit issues with this algorithm, and have not been tested.
+    uint waveID = localID / WaveGetLaneCount();
+    if (WaveIsFirstLane())
+        gs_FFX_PARALLELSORT_LDSSums[waveID] = waveReduced;
+
+    // Wait for everyone to catch up
+    GroupMemoryBarrierWithGroupSync();
+
+    // First wave worth of threads sum up wave reductions
+    if (!waveID)
+        waveReduced = WaveActiveSum((localID < FFX_PARALLELSORT_THREADGROUP_SIZE / WaveGetLaneCount()) ? gs_FFX_PARALLELSORT_LDSSums[localID] : 0);
+
+    // Returned the reduced sum
+    return waveReduced;
+#else
+    // No wave ops, do a stupidly slow emulation (should be possible to make it faster!)
+    //@TODO: not working correctly yet!
+    gs_FFX_PARALLELSORT_LDSSums[localID] = localSum;
+    GroupMemoryBarrierWithGroupSync();
+    uint reduced = 0;
+    for (uint i = 0; i < FFX_PARALLELSORT_THREADGROUP_SIZE; ++i)
+        reduced += gs_FFX_PARALLELSORT_LDSSums[i];
+    return reduced;
+#endif
+}
+
+void ffxParallelSortReduceCount(uint localID, uint groupID)
+{
+    uint NumReduceThreadgroupPerBin = FfxNumReduceThreadgroupPerBin();
+    uint NumThreadGroups = FfxNumThreadGroups();
+
+    // Figure out what bin data we are reducing
+    uint BinID = groupID / NumReduceThreadgroupPerBin;
+    uint BinOffset = BinID * NumThreadGroups;
+
+    // Get the base index for this thread group
+    uint BaseIndex = (groupID % NumReduceThreadgroupPerBin) * FFX_PARALLELSORT_ELEMENTS_PER_THREAD * FFX_PARALLELSORT_THREADGROUP_SIZE;
+
+    // Calculate partial sums for entries this thread reads in
+    uint threadgroupSum = 0;
+    for (uint i = 0; i < FFX_PARALLELSORT_ELEMENTS_PER_THREAD; ++i)
+    {
+        uint DataIndex = BaseIndex + (i * FFX_PARALLELSORT_THREADGROUP_SIZE) + localID;
+        threadgroupSum += (DataIndex < NumThreadGroups) ? FfxLoadSum(BinOffset + DataIndex) : 0;
+    }
+
+    // Reduce across the entirety of the thread group
+    threadgroupSum = ffxParallelSortThreadgroupReduce(threadgroupSum, localID);
+
+    // First thread of the group writes out the reduced sum for the bin
+    if (localID == 0)
+        FfxStoreReduce(groupID, threadgroupSum);
+
+    // What this will look like in the reduced table is:
+    //	[ [bin0 ... bin0] [bin1 ... bin1] ... ]
+}
+
+uint ffxParallelSortBlockScanPrefix(uint localSum, uint localID)
+{
+#if defined(SHADER_AVAILABLE_WAVEBASIC)
+    // Do wave local scan-prefix
+    uint wavePrefixed = WavePrefixSum(localSum);
+
+    // Since we are dealing with thread group sizes greater than HW wave size, we need to account for what wave we are in.
+    uint waveID = localID / WaveGetLaneCount();
+    uint laneID = WaveGetLaneIndex();
+
+    // Last element in a wave writes out partial sum to LDS
+    if (laneID == WaveGetLaneCount() - 1)
+        gs_FFX_PARALLELSORT_LDSSums[waveID] = wavePrefixed + localSum;
+
+    // Wait for everyone to catch up
+    GroupMemoryBarrierWithGroupSync();
+
+    // First wave prefixes partial sums
+    if (!waveID)
+        gs_FFX_PARALLELSORT_LDSSums[localID] = WavePrefixSum(gs_FFX_PARALLELSORT_LDSSums[localID]);
+
+    // Wait for everyone to catch up
+    GroupMemoryBarrierWithGroupSync();
+
+    // Add the partial sums back to each wave prefix
+    wavePrefixed += gs_FFX_PARALLELSORT_LDSSums[waveID];
+
+    return wavePrefixed;
+#else
+    // No wave ops, do a stupidly slow emulation (should be possible to make it faster!)
+    //@TODO: not working correctly yet!
+    gs_FFX_PARALLELSORT_LDSSums[localID] = localSum;
+    GroupMemoryBarrierWithGroupSync();
+    uint prefix = 0;
+    for (uint i = 0; i < localID; ++i)
+    {
+        prefix += gs_FFX_PARALLELSORT_LDSSums[i];
+    }
+    GroupMemoryBarrierWithGroupSync();
+    return prefix;
+#endif
+}
+
+// This is to transform uncoalesced loads into coalesced loads and
+// then scattered loads from LDS
+groupshared uint gs_FFX_PARALLELSORT_LDS[FFX_PARALLELSORT_ELEMENTS_PER_THREAD][FFX_PARALLELSORT_THREADGROUP_SIZE];
+void ffxParallelSortScanPrefix(uint numValuesToScan, uint localID, uint groupID, uint BinOffset, uint BaseIndex, bool AddPartialSums)
+{
+    uint i;
+
+    // Perform coalesced loads into LDS
+    for (i = 0; i < FFX_PARALLELSORT_ELEMENTS_PER_THREAD; i++)
+    {
+        uint DataIndex = BaseIndex + (i * FFX_PARALLELSORT_THREADGROUP_SIZE) + localID;
+
+        uint col = ((i * FFX_PARALLELSORT_THREADGROUP_SIZE) + localID) / FFX_PARALLELSORT_ELEMENTS_PER_THREAD;
+        uint row = ((i * FFX_PARALLELSORT_THREADGROUP_SIZE) + localID) % FFX_PARALLELSORT_ELEMENTS_PER_THREAD;
+        gs_FFX_PARALLELSORT_LDS[row][col] = (DataIndex < numValuesToScan) ? FfxLoadScanSource(BinOffset + DataIndex) : 0;
+    }
+
+    // Wait for everyone to catch up
+    GroupMemoryBarrierWithGroupSync();
+
+    uint threadgroupSum = 0;
+    // Calculate the local scan-prefix for current thread
+    for (i = 0; i < FFX_PARALLELSORT_ELEMENTS_PER_THREAD; i++)
+    {
+        uint tmp = gs_FFX_PARALLELSORT_LDS[i][localID];
+        gs_FFX_PARALLELSORT_LDS[i][localID] = threadgroupSum;
+        threadgroupSum += tmp;
+    }
+
+    // Scan prefix partial sums
+    threadgroupSum = ffxParallelSortBlockScanPrefix(threadgroupSum, localID);
+
+    // Add reduced partial sums if requested
+    uint partialSum = 0;
+    if (AddPartialSums)
+    {
+        // Partial sum additions are a little special as they are tailored to the optimal number of
+        // thread groups we ran in the beginning, so need to take that into account
+        partialSum = FfxLoadScanScratch(groupID);
+    }
+
+    // Add the block scanned-prefixes back in
+    for (i = 0; i < FFX_PARALLELSORT_ELEMENTS_PER_THREAD; i++)
+        gs_FFX_PARALLELSORT_LDS[i][localID] += threadgroupSum;
+
+    // Wait for everyone to catch up
+    GroupMemoryBarrierWithGroupSync();
+
+    // Perform coalesced writes to scan dst
+    for (i = 0; i < FFX_PARALLELSORT_ELEMENTS_PER_THREAD; i++)
+    {
+        uint DataIndex = BaseIndex + (i * FFX_PARALLELSORT_THREADGROUP_SIZE) + localID;
+
+        uint col = ((i * FFX_PARALLELSORT_THREADGROUP_SIZE) + localID) / FFX_PARALLELSORT_ELEMENTS_PER_THREAD;
+        uint row = ((i * FFX_PARALLELSORT_THREADGROUP_SIZE) + localID) % FFX_PARALLELSORT_ELEMENTS_PER_THREAD;
+
+        if (DataIndex < numValuesToScan)
+            FfxStoreScanDest(BinOffset + DataIndex, gs_FFX_PARALLELSORT_LDS[row][col] + partialSum);
+    }
+}
+
+// Offset cache to avoid loading the offsets all the time
+groupshared uint gs_FFX_PARALLELSORT_BinOffsetCache[FFX_PARALLELSORT_THREADGROUP_SIZE];
+// Local histogram for offset calculations
+groupshared uint gs_FFX_PARALLELSORT_LocalHistogram[FFX_PARALLELSORT_SORT_BIN_COUNT];
+// Scratch area for algorithm
+groupshared uint gs_FFX_PARALLELSORT_LDSScratch[FFX_PARALLELSORT_THREADGROUP_SIZE];
+
+void ffxParallelSortScatterUInt(uint localID, uint groupID, uint ShiftBit)
+{
+    uint NumBlocksPerThreadGroup = FfxNumBlocksPerThreadGroup();
+    uint NumThreadGroups = FfxNumThreadGroups();
+    uint NumThreadGroupsWithAdditionalBlocks = FfxNumThreadGroupsWithAdditionalBlocks();
+    uint NumKeys = FfxNumKeys();
+
+    // Load the sort bin threadgroup offsets into LDS for faster referencing
+    if (localID < FFX_PARALLELSORT_SORT_BIN_COUNT)
+        gs_FFX_PARALLELSORT_BinOffsetCache[localID] = FfxLoadSum(localID * NumThreadGroups + groupID);
+
+    // Wait for everyone to catch up
+    GroupMemoryBarrierWithGroupSync();
+
+    // Data is processed in blocks, and how many we process can changed based on how much data we are processing
+    // versus how many thread groups we are processing with
+    int BlockSize = FFX_PARALLELSORT_ELEMENTS_PER_THREAD * FFX_PARALLELSORT_THREADGROUP_SIZE;
+
+    // Figure out this thread group's index into the block data (taking into account thread groups that need to do extra reads)
+    uint ThreadgroupBlockStart = (BlockSize * NumBlocksPerThreadGroup * groupID);
+    uint NumBlocksToProcess = NumBlocksPerThreadGroup;
+
+    if (groupID >= NumThreadGroups - NumThreadGroupsWithAdditionalBlocks)
+    {
+        ThreadgroupBlockStart += (groupID - (NumThreadGroups - NumThreadGroupsWithAdditionalBlocks)) * BlockSize;
+        NumBlocksToProcess++;
+    }
+
+    // Get the block start index for this thread
+    uint BlockIndex = ThreadgroupBlockStart + localID;
+
+    // Count value occurences
+    uint newCount;
+    for (uint BlockCount = 0; BlockCount < NumBlocksToProcess; BlockCount++, BlockIndex += BlockSize)
+    {
+        uint DataIndex = BlockIndex;
+
+        // Pre-load the key values in order to hide some of the read latency
+        uint srcKeys[FFX_PARALLELSORT_ELEMENTS_PER_THREAD];
+        srcKeys[0] = FfxLoadKey(DataIndex);
+        srcKeys[1] = FfxLoadKey(DataIndex + FFX_PARALLELSORT_THREADGROUP_SIZE);
+        srcKeys[2] = FfxLoadKey(DataIndex + (FFX_PARALLELSORT_THREADGROUP_SIZE * 2));
+        srcKeys[3] = FfxLoadKey(DataIndex + (FFX_PARALLELSORT_THREADGROUP_SIZE * 3));
+
+        uint srcValues[FFX_PARALLELSORT_ELEMENTS_PER_THREAD];
+        srcValues[0] = FfxLoadPayload(DataIndex);
+        srcValues[1] = FfxLoadPayload(DataIndex + FFX_PARALLELSORT_THREADGROUP_SIZE);
+        srcValues[2] = FfxLoadPayload(DataIndex + (FFX_PARALLELSORT_THREADGROUP_SIZE * 2));
+        srcValues[3] = FfxLoadPayload(DataIndex + (FFX_PARALLELSORT_THREADGROUP_SIZE * 3));
+
+        for (int i = 0; i < FFX_PARALLELSORT_ELEMENTS_PER_THREAD; i++)
+        {
+            // Clear the local histogram
+            if (localID < FFX_PARALLELSORT_SORT_BIN_COUNT)
+                gs_FFX_PARALLELSORT_LocalHistogram[localID] = 0;
+
+            uint localKey = (DataIndex < NumKeys ? srcKeys[i] : 0xffffffff);
+            uint localValue = (DataIndex < NumKeys ? srcValues[i] : 0);
+
+            // Sort the keys locally in LDS
+            for (uint bitShift = 0; bitShift < FFX_PARALLELSORT_SORT_BITS_PER_PASS; bitShift += 2)
+            {
+                // Figure out the keyIndex
+                uint keyIndex = (localKey >> ShiftBit) & 0xf;
+                uint bitKey = (keyIndex >> bitShift) & 0x3;
+
+                // Create a packed histogram
+                uint packedHistogram = 1U << (bitKey * 8);
+
+                // Sum up all the packed keys (generates counted offsets up to current thread group)
+                uint localSum = ffxParallelSortBlockScanPrefix(packedHistogram, localID);
+
+                // Last thread stores the updated histogram counts for the thread group
+                // Scratch = 0xsum3|sum2|sum1|sum0 for thread group
+                if (localID == (FFX_PARALLELSORT_THREADGROUP_SIZE - 1))
+                    gs_FFX_PARALLELSORT_LDSScratch[0] = localSum + packedHistogram;
+
+                // Wait for everyone to catch up
+                GroupMemoryBarrierWithGroupSync();
+
+                // Load the sums value for the thread group
+                packedHistogram = gs_FFX_PARALLELSORT_LDSScratch[0];
+
+                // Add prefix offsets for all 4 bit "keys" (packedHistogram = 0xsum2_1_0|sum1_0|sum0|0)
+                packedHistogram = (packedHistogram << 8) + (packedHistogram << 16) + (packedHistogram << 24);
+
+                // Calculate the proper offset for this thread's value
+                localSum += packedHistogram;
+
+                // Calculate target offset
+                uint keyOffset = (localSum >> (bitKey * 8)) & 0xff;
+
+                // Re-arrange the keys (store, sync, load)
+                gs_FFX_PARALLELSORT_LDSSums[keyOffset] = localKey;
+                GroupMemoryBarrierWithGroupSync();
+                localKey = gs_FFX_PARALLELSORT_LDSSums[localID];
+
+                // Wait for everyone to catch up
+                GroupMemoryBarrierWithGroupSync();
+
+                // Re-arrange the values if we have them (store, sync, load)
+                gs_FFX_PARALLELSORT_LDSSums[keyOffset] = localValue;
+                GroupMemoryBarrierWithGroupSync();
+                localValue = gs_FFX_PARALLELSORT_LDSSums[localID];
+
+                // Wait for everyone to catch up
+                GroupMemoryBarrierWithGroupSync();
+            }
+
+            // Need to recalculate the keyIndex on this thread now that values have been copied around the thread group
+            uint keyIndex = (localKey >> ShiftBit) & 0xf;
+
+            // Reconstruct histogram
+            InterlockedAdd(gs_FFX_PARALLELSORT_LocalHistogram[keyIndex], 1);
+
+            // Wait for everyone to catch up
+            GroupMemoryBarrierWithGroupSync();
+
+            // Prefix histogram
+            uint histogramLocalSum = localID < FFX_PARALLELSORT_SORT_BIN_COUNT ? gs_FFX_PARALLELSORT_LocalHistogram[localID] : 0;
+            #if defined(SHADER_AVAILABLE_WAVEBASIC)
+            uint histogramPrefixSum = WavePrefixSum(histogramLocalSum);
+            #else
+            // No wave ops, do a stupidly slow emulation (should be possible to make it faster!)
+            //@TODO: not working correctly yet!
+            gs_FFX_PARALLELSORT_LDSSums[localID] = histogramLocalSum;
+            GroupMemoryBarrierWithGroupSync();
+            uint histogramPrefixSum = 0;
+            for (uint hi = 0; hi < localID; ++hi)
+                histogramPrefixSum += gs_FFX_PARALLELSORT_LDSSums[hi];
+            GroupMemoryBarrierWithGroupSync();
+            #endif
+
+            // Broadcast prefix-sum via LDS
+            if (localID < FFX_PARALLELSORT_SORT_BIN_COUNT)
+                gs_FFX_PARALLELSORT_LDSScratch[localID] = histogramPrefixSum;
+
+            // Get the global offset for this key out of the cache
+            uint globalOffset = gs_FFX_PARALLELSORT_BinOffsetCache[keyIndex];
+
+            // Wait for everyone to catch up
+            GroupMemoryBarrierWithGroupSync();
+
+            // Get the local offset (at this point the keys are all in increasing order from 0 -> num bins in localID 0 -> thread group size)
+            uint localOffset = localID - gs_FFX_PARALLELSORT_LDSScratch[keyIndex];
+
+            // Write to destination
+            uint totalOffset = globalOffset + localOffset;
+
+            if (totalOffset < NumKeys)
+            {
+                FfxStoreKey(totalOffset, localKey);
+                FfxStorePayload(totalOffset, localValue);
+            }
+
+            // Wait for everyone to catch up
+            GroupMemoryBarrierWithGroupSync();
+
+            // Update the cached histogram for the next set of entries
+            if (localID < FFX_PARALLELSORT_SORT_BIN_COUNT)
+                gs_FFX_PARALLELSORT_BinOffsetCache[localID] += gs_FFX_PARALLELSORT_LocalHistogram[localID];
+
+            DataIndex += FFX_PARALLELSORT_THREADGROUP_SIZE;	// Increase the data offset by thread group size
+        }
+    }
+}
+
+// -------- Kernel entry points
+
+// Buffers: rw_sum_table, rw_reduce_table
+[numthreads(FFX_PARALLELSORT_THREADGROUP_SIZE, 1, 1)]
+void FfxParallelSortReduce(uint LocalID : SV_GroupThreadID, uint GroupID : SV_GroupID)
+{
+    ffxParallelSortReduceCount(LocalID, GroupID);
+}
+
+// Buffers: rw_scan_source, rw_scan_dest, rw_scan_scratch
+[numthreads(FFX_PARALLELSORT_THREADGROUP_SIZE, 1, 1)]
+void FfxParallelSortScanAdd(uint LocalID : SV_GroupThreadID, uint GroupID : SV_GroupID)
+{
+    // When doing adds, we need to access data differently because reduce
+    // has a more specialized access pattern to match optimized count
+    // Access needs to be done similarly to reduce
+    // Figure out what bin data we are reducing
+    uint BinID = GroupID / FfxNumReduceThreadgroupPerBin();
+    uint BinOffset = BinID * FfxNumThreadGroups();
+
+    // Get the base index for this thread group
+    uint BaseIndex = (GroupID % FfxNumReduceThreadgroupPerBin()) * FFX_PARALLELSORT_ELEMENTS_PER_THREAD * FFX_PARALLELSORT_THREADGROUP_SIZE;
+
+    ffxParallelSortScanPrefix(FfxNumThreadGroups(), LocalID, GroupID, BinOffset, BaseIndex, true);
+}
+
+// Buffers: rw_scan_source, rw_scan_dest
+[numthreads(FFX_PARALLELSORT_THREADGROUP_SIZE, 1, 1)]
+void FfxParallelSortScan(uint LocalID : SV_GroupThreadID, uint GroupID : SV_GroupID)
+{
+    uint BaseIndex = FFX_PARALLELSORT_ELEMENTS_PER_THREAD * FFX_PARALLELSORT_THREADGROUP_SIZE * GroupID;
+    ffxParallelSortScanPrefix(FfxNumScanValues(), LocalID, GroupID, 0, BaseIndex, false);
+}
+
+// Buffers: rw_source_keys, rw_dest_keys, rw_sum_table, rw_source_payloads, rw_dest_payloads
+[numthreads(FFX_PARALLELSORT_THREADGROUP_SIZE, 1, 1)]
+void FfxParallelSortScatter(uint LocalID : SV_GroupThreadID, uint GroupID : SV_GroupID)
+{
+    ffxParallelSortScatterUInt(LocalID, GroupID, FfxShiftBit());
+}
+
+// Buffers: rw_source_keys, rw_sum_table
+[numthreads(FFX_PARALLELSORT_THREADGROUP_SIZE, 1, 1)]
+void FfxParallelSortCount(uint LocalID : SV_GroupThreadID, uint GroupID : SV_GroupID)
+{
+    ffxParallelSortCountUInt(LocalID, GroupID, FfxShiftBit());
+}

--- a/Assets/External/FfxParallelSort/FfxParallelSort.compute.meta
+++ b/Assets/External/FfxParallelSort/FfxParallelSort.compute.meta
@@ -1,0 +1,7 @@
+fileFormatVersion: 2
+guid: dec36776b6c843544a1f6f9b436a4474
+ComputeShaderImporter:
+  externalObjects: {}
+  userData: 
+  assetBundleName: 
+  assetBundleVariant: 

--- a/Assets/External/FfxParallelSort/FfxParallelSort.cs
+++ b/Assets/External/FfxParallelSort/FfxParallelSort.cs
@@ -1,0 +1,207 @@
+// Originally based on FidelityFX SDK, Copyright © 2023 Advanced Micro Devices, Inc., MIT license
+// https://github.com/GPUOpen-Effects/FidelityFX-ParallelSort v1.1.1
+
+using UnityEngine;
+using UnityEngine.Assertions;
+using UnityEngine.Rendering;
+
+public class FfxParallelSort
+{
+    // These need to match constants in the compute shader
+    const uint FFX_PARALLELSORT_ELEMENTS_PER_THREAD = 4;
+    const uint FFX_PARALLELSORT_THREADGROUP_SIZE = 128;
+    const int FFX_PARALLELSORT_SORT_BITS_PER_PASS = 4;
+    const uint FFX_PARALLELSORT_SORT_BIN_COUNT = 1u << FFX_PARALLELSORT_SORT_BITS_PER_PASS;
+    // The maximum number of thread groups to run in parallel. Modifying this value can help or hurt GPU occupancy,
+    // but is very hardware class specific
+    const uint FFX_PARALLELSORT_MAX_THREADGROUPS_TO_RUN = 800;
+
+    public struct Args
+    {
+        public uint             count;
+        public GraphicsBuffer   inputKeys;
+        public GraphicsBuffer   inputValues;
+        public SupportResources resources;
+        internal int workGroupCount;
+    }
+
+    public struct SupportResources
+    {
+        public GraphicsBuffer sortScratchBuffer;
+        public GraphicsBuffer payloadScratchBuffer;
+        public GraphicsBuffer scratchBuffer;
+        public GraphicsBuffer reducedScratchBuffer;
+
+        public static SupportResources Load(uint count)
+        {
+            uint BlockSize = FFX_PARALLELSORT_ELEMENTS_PER_THREAD * FFX_PARALLELSORT_THREADGROUP_SIZE;
+            uint NumBlocks = DivRoundUp(count, BlockSize);
+            uint NumReducedBlocks = DivRoundUp(NumBlocks, BlockSize);
+
+            uint scratchBufferSize = FFX_PARALLELSORT_SORT_BIN_COUNT * NumBlocks;
+            uint reduceScratchBufferSize = FFX_PARALLELSORT_SORT_BIN_COUNT * NumReducedBlocks;
+
+            var target = GraphicsBuffer.Target.Structured;
+            var resources = new SupportResources
+            {
+                sortScratchBuffer = new GraphicsBuffer(target, (int)count, 4) { name = "FfxSortSortScratch" },
+                payloadScratchBuffer = new GraphicsBuffer(target, (int)count, 4) { name = "FfxSortPayloadScratch" },
+                scratchBuffer = new GraphicsBuffer(target, (int)scratchBufferSize, 4) { name = "FfxSortScratch" },
+                reducedScratchBuffer = new GraphicsBuffer(target, (int)reduceScratchBufferSize, 4) { name = "FfxSortReducedScratch" },
+            };
+            return resources;
+        }
+
+        public void Dispose()
+        {
+            sortScratchBuffer?.Dispose();
+            payloadScratchBuffer?.Dispose();
+            scratchBuffer?.Dispose();
+            reducedScratchBuffer?.Dispose();
+
+            sortScratchBuffer = null;
+            payloadScratchBuffer = null;
+            scratchBuffer = null;
+            reducedScratchBuffer = null;
+        }
+    }
+
+    readonly ComputeShader m_CS;
+    readonly int m_KernelReduce = -1;
+    readonly int m_KernelScanAdd = -1;
+    readonly int m_KernelScan = -1;
+    readonly int m_KernelScatter = -1;
+    readonly int m_KernelSum = -1;
+    readonly bool m_Valid;
+
+    public bool Valid => m_Valid;
+
+    public FfxParallelSort(ComputeShader cs)
+    {
+        m_CS = cs;
+        if (cs)
+        {
+            m_KernelReduce = cs.FindKernel("FfxParallelSortReduce");
+            m_KernelScanAdd = cs.FindKernel("FfxParallelSortScanAdd");
+            m_KernelScan = cs.FindKernel("FfxParallelSortScan");
+            m_KernelScatter = cs.FindKernel("FfxParallelSortScatter");
+            m_KernelSum = cs.FindKernel("FfxParallelSortCount");
+        }
+
+        m_Valid = m_KernelReduce >= 0 &&
+                  m_KernelScanAdd >= 0 &&
+                  m_KernelScan >= 0 &&
+                  m_KernelScatter >= 0 &&
+                  m_KernelSum >= 0;
+        if (m_Valid)
+        {
+            if (!cs.IsSupported(m_KernelReduce) ||
+                !cs.IsSupported(m_KernelScanAdd) ||
+                !cs.IsSupported(m_KernelScan) ||
+                !cs.IsSupported(m_KernelScatter) ||
+                !cs.IsSupported(m_KernelSum))
+            {
+                m_Valid = false;
+            }
+        }
+    }
+
+    static uint DivRoundUp(uint x, uint y) => (x + y - 1) / y;
+
+    struct SortConstants
+    {
+        public uint numKeys;                              // The number of keys to sort
+        public uint numBlocksPerThreadGroup;              // How many blocks of keys each thread group needs to process
+        public uint numThreadGroups;                      // How many thread groups are being run concurrently for sort
+        public uint numThreadGroupsWithAdditionalBlocks;  // How many thread groups need to process additional block data
+        public uint numReduceThreadgroupPerBin;           // How many thread groups are summed together for each reduced bin entry
+        public uint numScanValues;                        // How many values to perform scan prefix (+ add) on
+        public uint shift;                                // What bits are being sorted (4 bit increments)
+        public uint padding;                              // Padding - unused
+    }
+
+    public void Dispatch(CommandBuffer cmd, Args args)
+    {
+        Assert.IsTrue(Valid);
+
+        GraphicsBuffer srcKeyBuffer = args.inputKeys;
+        GraphicsBuffer srcPayloadBuffer = args.inputValues;
+        GraphicsBuffer dstKeyBuffer = args.resources.sortScratchBuffer;
+        GraphicsBuffer dstPayloadBuffer = args.resources.payloadScratchBuffer;
+
+        // Initialize constants for the sort job
+        SortConstants constants = default;
+        constants.numKeys = args.count;
+
+        uint BlockSize = FFX_PARALLELSORT_ELEMENTS_PER_THREAD * FFX_PARALLELSORT_THREADGROUP_SIZE;
+        uint NumBlocks = DivRoundUp(args.count, BlockSize);
+
+        // Figure out data distribution
+        uint numThreadGroupsToRun = FFX_PARALLELSORT_MAX_THREADGROUPS_TO_RUN;
+        uint BlocksPerThreadGroup = (NumBlocks / numThreadGroupsToRun);
+        constants.numThreadGroupsWithAdditionalBlocks = NumBlocks % numThreadGroupsToRun;
+
+        if (NumBlocks < numThreadGroupsToRun)
+        {
+            BlocksPerThreadGroup = 1;
+            numThreadGroupsToRun = NumBlocks;
+            constants.numThreadGroupsWithAdditionalBlocks = 0;
+        }
+
+        constants.numThreadGroups = numThreadGroupsToRun;
+        constants.numBlocksPerThreadGroup = BlocksPerThreadGroup;
+
+        // Calculate the number of thread groups to run for reduction (each thread group can process BlockSize number of entries)
+        uint numReducedThreadGroupsToRun = FFX_PARALLELSORT_SORT_BIN_COUNT * ((BlockSize > numThreadGroupsToRun) ? 1 : (numThreadGroupsToRun + BlockSize - 1) / BlockSize);
+        constants.numReduceThreadgroupPerBin = numReducedThreadGroupsToRun / FFX_PARALLELSORT_SORT_BIN_COUNT;
+        constants.numScanValues = numReducedThreadGroupsToRun;	// The number of reduce thread groups becomes our scan count (as each thread group writes out 1 value that needs scan prefix)
+
+        // Setup overall constants
+        cmd.SetComputeIntParam(m_CS, "numKeys", (int)constants.numKeys);
+        cmd.SetComputeIntParam(m_CS, "numBlocksPerThreadGroup", (int)constants.numBlocksPerThreadGroup);
+        cmd.SetComputeIntParam(m_CS, "numThreadGroups", (int)constants.numThreadGroups);
+        cmd.SetComputeIntParam(m_CS, "numThreadGroupsWithAdditionalBlocks", (int)constants.numThreadGroupsWithAdditionalBlocks);
+        cmd.SetComputeIntParam(m_CS, "numReduceThreadgroupPerBin", (int)constants.numReduceThreadgroupPerBin);
+        cmd.SetComputeIntParam(m_CS, "numScanValues", (int)constants.numScanValues);
+
+        // Execute the sort algorithm in 4-bit increments
+        constants.shift = 0;
+        for (uint i = 0; constants.shift < 32; constants.shift += FFX_PARALLELSORT_SORT_BITS_PER_PASS, ++i)
+        {
+            cmd.SetComputeIntParam(m_CS, "shift", (int)constants.shift);
+
+            // Sum
+            cmd.SetComputeBufferParam(m_CS, m_KernelSum, "rw_source_keys", srcKeyBuffer);
+            cmd.SetComputeBufferParam(m_CS, m_KernelSum, "rw_sum_table", args.resources.scratchBuffer);
+            cmd.DispatchCompute(m_CS, m_KernelSum, (int)numThreadGroupsToRun, 1, 1);
+
+            // Reduce
+            cmd.SetComputeBufferParam(m_CS, m_KernelReduce, "rw_sum_table", args.resources.scratchBuffer);
+            cmd.SetComputeBufferParam(m_CS, m_KernelReduce, "rw_reduce_table", args.resources.reducedScratchBuffer);
+            cmd.DispatchCompute(m_CS, m_KernelReduce, (int)numReducedThreadGroupsToRun, 1, 1);
+
+            // Scan
+            cmd.SetComputeBufferParam(m_CS, m_KernelScan, "rw_scan_source", args.resources.reducedScratchBuffer);
+            cmd.SetComputeBufferParam(m_CS, m_KernelScan, "rw_scan_dest", args.resources.reducedScratchBuffer);
+            cmd.DispatchCompute(m_CS, m_KernelScan, 1, 1, 1);
+
+            // Scan add
+            cmd.SetComputeBufferParam(m_CS, m_KernelScanAdd, "rw_scan_source", args.resources.scratchBuffer);
+            cmd.SetComputeBufferParam(m_CS, m_KernelScanAdd, "rw_scan_dest", args.resources.scratchBuffer);
+            cmd.SetComputeBufferParam(m_CS, m_KernelScanAdd, "rw_scan_scratch", args.resources.reducedScratchBuffer);
+            cmd.DispatchCompute(m_CS, m_KernelScanAdd, (int)numReducedThreadGroupsToRun, 1, 1);
+
+            // Scatter
+            cmd.SetComputeBufferParam(m_CS, m_KernelScatter, "rw_source_keys", srcKeyBuffer);
+            cmd.SetComputeBufferParam(m_CS, m_KernelScatter, "rw_dest_keys", dstKeyBuffer);
+            cmd.SetComputeBufferParam(m_CS, m_KernelScatter, "rw_sum_table", args.resources.scratchBuffer);
+            cmd.SetComputeBufferParam(m_CS, m_KernelScatter, "rw_source_payloads", srcPayloadBuffer);
+            cmd.SetComputeBufferParam(m_CS, m_KernelScatter, "rw_dest_payloads", dstPayloadBuffer);
+            cmd.DispatchCompute(m_CS, m_KernelScatter, (int)numThreadGroupsToRun, 1, 1);
+
+            // Swap
+            (srcKeyBuffer, dstKeyBuffer) = (dstKeyBuffer, srcKeyBuffer);
+            (srcPayloadBuffer, dstPayloadBuffer) = (dstPayloadBuffer, srcPayloadBuffer);
+        }
+    }
+}

--- a/Assets/External/FfxParallelSort/FfxParallelSort.cs.meta
+++ b/Assets/External/FfxParallelSort/FfxParallelSort.cs.meta
@@ -1,0 +1,11 @@
+fileFormatVersion: 2
+guid: 65a55f12dc9f42e4196260841dd87c15
+MonoImporter:
+  externalObjects: {}
+  serializedVersion: 2
+  defaultReferences: []
+  executionOrder: 0
+  icon: {instanceID: 0}
+  userData: 
+  assetBundleName: 
+  assetBundleVariant: 

--- a/Assets/Scene.unity
+++ b/Assets/Scene.unity
@@ -343,7 +343,9 @@ MonoBehaviour:
   m_ScaleDown: 1
   m_Material: {fileID: 2100000, guid: c997de094bd0b4213b3b99a55969f48b, type: 2}
   m_CSSplatUtilities: {fileID: 7200000, guid: ec84f78b836bd4f96a105d6b804f08bd, type: 3}
-  m_CSGpuSort: {fileID: 7200000, guid: e6e2efa91deac4ac38e81763e4d34687, type: 3}
+  m_CSIslandSort: {fileID: 7200000, guid: e6e2efa91deac4ac38e81763e4d34687, type: 3}
+  m_CSFfxSort: {fileID: 7200000, guid: dec36776b6c843544a1f6f9b436a4474, type: 3}
+  m_PreferFfxSort: 1
 --- !u!4 &1609192435
 Transform:
   m_ObjectHideFlags: 0

--- a/Assets/Scripts/GaussianSplatRenderer.cs
+++ b/Assets/Scripts/GaussianSplatRenderer.cs
@@ -19,15 +19,26 @@ public class GaussianSplatRenderer : MonoBehaviour
     [FolderPicker(kPointCloudPly)]
     public string m_PointCloudFolder;
 
+    [Tooltip("Use iteration_30000 point cloud if available. Otherwise uses iteration_7000.")]
     public bool m_Use30kVersion = false;
-    [Range(1,30)]
-    public int m_ScaleDown = 10;
+
+    [Space]
+    [Tooltip("Gaussian splatting material")]
     public Material m_Material;
 
+    [Tooltip("Gaussian splatting utilities compute shader")]
     public ComputeShader m_CSSplatUtilities;
-    [FormerlySerializedAs("m_CSGpuSort")] public ComputeShader m_CSIslandSort;
+    [Tooltip("'Island' bitonic sort compute shader")]
+    [FormerlySerializedAs("m_CSGpuSort")]
+    public ComputeShader m_CSIslandSort;
+    [Tooltip("AMD FidelityFX sort compute shader")]
     public ComputeShader m_CSFfxSort;
+    [Tooltip("Use AMD FidelityFX sorting when available, instead of the slower bitonic sort")]
     public bool m_PreferFfxSort = true; // use AMD FidelityFX sort if available (currently: DX12, Vulkan, Metal, but *not* DX11)
+
+    [Tooltip("Reduce the number of splats used, by taking only 1/N of the total amount. Only for debugging!")]
+    [Range(1,30)]
+    public int m_ScaleDown = 10;
 
     // input file splat data is expected to be in this format
     public struct InputSplat

--- a/Assets/Scripts/GaussianSplatRenderer.cs.meta
+++ b/Assets/Scripts/GaussianSplatRenderer.cs.meta
@@ -4,10 +4,10 @@ MonoImporter:
   externalObjects: {}
   serializedVersion: 2
   defaultReferences:
-  - m_DataFile: {instanceID: 0}
   - m_Material: {fileID: 2100000, guid: c997de094bd0b4213b3b99a55969f48b, type: 2}
   - m_CSSplatUtilities: {fileID: 7200000, guid: ec84f78b836bd4f96a105d6b804f08bd, type: 3}
-  - m_CSGpuSort: {fileID: 7200000, guid: e6e2efa91deac4ac38e81763e4d34687, type: 3}
+  - m_CSIslandSort: {fileID: 7200000, guid: e6e2efa91deac4ac38e81763e4d34687, type: 3}
+  - m_CSFfxSort: {fileID: 7200000, guid: dec36776b6c843544a1f6f9b436a4474, type: 3}
   executionOrder: 0
   icon: {instanceID: 0}
   userData: 

--- a/ProjectSettings/ProjectSettings.asset
+++ b/ProjectSettings/ProjectSettings.asset
@@ -340,6 +340,9 @@ PlayerSettings:
   - m_BuildTarget: WebGLSupport
     m_APIs: 0b000000
     m_Automatic: 1
+  - m_BuildTarget: WindowsStandaloneSupport
+    m_APIs: 120000000200000015000000
+    m_Automatic: 0
   m_BuildTargetVRSettings:
   - m_BuildTarget: Standalone
     m_Enabled: 0

--- a/readme.md
+++ b/readme.md
@@ -43,4 +43,5 @@ My own blog posts about all this _(so far... not that many!)_:
 ## External Code Used
 
 - [zanders3/json](https://github.com/zanders3/json), MIT license, (c) 2018 Alex Parker.
-- GPU sorting code adapted from [Tim Gfrerer blog post](https://poniesandlight.co.uk/reflect/bitonic_merge_sort/).
+- "Island" GPU sorting code adapted from [Tim Gfrerer blog post](https://poniesandlight.co.uk/reflect/bitonic_merge_sort/).
+- "Ffx" GPU sorting code is [AMD FidelityFX ParallelSort](https://github.com/GPUOpen-Effects/FidelityFX-ParallelSort), ported to Unity by me.

--- a/readme.md
+++ b/readme.md
@@ -50,7 +50,8 @@ My own blog posts about all this _(so far... not that many!)_:
   * Unity, DX12 or Vulkan: 13.4ms (75FPS) - 10.1ms rendering, 3.3ms sorting. 2.1GB VRAM usage.
   * Unity, DX11: 21.8ms (46FPS) - 9.9ms rendering, 11.9ms sorting.
 * Mac (Apple M1 Max):
-  * Unity, Metal: 108ms (9FPS).
+  * Unity, Metal: 80.6ms (12FPS) - with FidelityFX GPU sort.
+  * Unity, Metal: 108ms (9FPS) - with bitonic GPU sort.
 
 ## External Code Used
 


### PR DESCRIPTION
Port the [ParallelSort v1.1.1](https://github.com/GPUOpen-Effects/FidelityFX-ParallelSort) from AMD FidelityFX to Unity. The original code is Copyright © 2023 Advanced Micro Devices, Inc., and under MIT license. Curiously enough, I don't have AMD hardware here to test, but works fine on NVIDIA (DX12 and Vulkan) and Apple (Metal).

The sorting itself gets down from 11.9ms down to 3.3ms on Windows. On a Mac seemingly a smaller speedup, but it's also hard to measure individual frame parts at least within Unity itself.

Note: FidelityFX sort requires "wave operations" which means it does not work on DX11. So when on DX11, the sorting falls back to the previous slower bitonic sort. I did a quick attempt at emulating/redoing the parts that require wave operations to at least "do something correct" on DX11, but did not get it working just yet.
