### PR TITLE
Precalc some splat data each frame

### DIFF
--- a/Assets/GSTestScene.unity
+++ b/Assets/GSTestScene.unity
@@ -347,6 +347,7 @@ MonoBehaviour:
   m_DisplayData: 0
   m_DisplayDataScale: 1
   m_RenderInSceneView: 1
+  m_ComputeView: 1
   m_PreferFfxSort: 1
   m_ShaderSplats: {fileID: 4800000, guid: ed800126ae8844a67aad1974ddddd59c, type: 3}
   m_ShaderComposite: {fileID: 4800000, guid: 7e184af7d01193a408eb916d8acafff9, type: 3}

--- a/Assets/GSTestScene.unity
+++ b/Assets/GSTestScene.unity
@@ -347,7 +347,6 @@ MonoBehaviour:
   m_DisplayData: 0
   m_DisplayDataScale: 1
   m_RenderInSceneView: 1
-  m_ComputeView: 1
   m_PreferFfxSort: 1
   m_ShaderSplats: {fileID: 4800000, guid: ed800126ae8844a67aad1974ddddd59c, type: 3}
   m_ShaderComposite: {fileID: 4800000, guid: 7e184af7d01193a408eb916d8acafff9, type: 3}

--- a/Assets/GaussianSplatting/Shaders/GaussianDebugRenderBoxes.shader
+++ b/Assets/GaussianSplatting/Shaders/GaussianDebugRenderBoxes.shader
@@ -70,8 +70,10 @@ v2f vert (uint vtxID : SV_VertexID, uint instID : SV_InstanceID)
         boxSize *= _SplatScale;
 
         float3x3 splatRotScaleMat = CalcMatrixFromRotationScale(boxRot, boxSize);
+        splatRotScaleMat = mul((float3x3)unity_ObjectToWorld, splatRotScaleMat);
 
-        centerWorldPos = splat.pos * float3(1,1,-1);
+        centerWorldPos = splat.pos;
+        centerWorldPos = mul(unity_ObjectToWorld, float4(centerWorldPos,1)).xyz;
 
         o.col.rgb = saturate(splat.sh.col);
         o.col.a = saturate(splat.opacity);
@@ -84,6 +86,7 @@ v2f vert (uint vtxID : SV_VertexID, uint instID : SV_InstanceID)
         localPos = localPos * 0.5 + 0.5;
         SplatChunkInfo chunk = _SplatChunks[instID];
         localPos = lerp(chunk.boundsMin.pos, chunk.boundsMax.pos, localPos);
+        localPos = mul(unity_ObjectToWorld, float4(localPos,1)).xyz;
 
         o.col.rgb = palette((float)instID / (float)_SplatChunkCount, half3(0.5,0.5,0.5), half3(0.5,0.5,0.5), half3(1,1,1), half3(0.0, 0.33, 0.67));
         o.col.a = 0.1;

--- a/Assets/GaussianSplatting/Shaders/GaussianDebugRenderPoints.shader
+++ b/Assets/GaussianSplatting/Shaders/GaussianDebugRenderPoints.shader
@@ -39,7 +39,8 @@ v2f vert (uint vtxID : SV_VertexID, uint instID : SV_InstanceID)
 
     SplatData splat = LoadSplatData(splatIndex);
 
-    float3 centerWorldPos = splat.pos * float3(1,1,-1);
+    float3 centerWorldPos = splat.pos;
+    centerWorldPos = mul(unity_ObjectToWorld, float4(centerWorldPos,1)).xyz;
 
     float4 centerClipPos = mul(UNITY_MATRIX_VP, float4(centerWorldPos, 1));
 

--- a/Assets/GaussianSplatting/Shaders/GaussianSplatting.hlsl
+++ b/Assets/GaussianSplatting/Shaders/GaussianSplatting.hlsl
@@ -365,4 +365,11 @@ SplatData LoadSplatDataRaw(uint2 coord2)
     return s;
 }
 
+struct SplatViewData
+{
+    float4 pos;
+    float4 conicRadius;
+    uint2 color; // 4xFP16
+};
+
 #endif // GAUSSIAN_SPLATTING_HLSL

--- a/Assets/GaussianSplatting/Shaders/RenderGaussianSplats.shader
+++ b/Assets/GaussianSplatting/Shaders/RenderGaussianSplats.shader
@@ -15,6 +15,10 @@ CGPROGRAM
 #pragma fragment frag
 #pragma require compute
 #pragma use_dxc metal vulkan
+#pragma multi_compile _ USE_VIEW_DATA
+
+// Metal DXC: 218ms
+// View splat data comp: 58ms
 
 #include "UnityCG.cginc"
 #include "GaussianSplatting.hlsl"
@@ -32,10 +36,43 @@ struct v2f
 float _SplatScale;
 uint _SHOrder;
 
+#if USE_VIEW_DATA
+StructuredBuffer<SplatViewData> _SplatViewData;
+#endif
+
 v2f vert (uint vtxID : SV_VertexID, uint instID : SV_InstanceID)
 {
     v2f o;
     instID = _OrderBuffer[instID];
+	
+#if USE_VIEW_DATA
+	SplatViewData view = _SplatViewData[instID];
+	o.col.r = f16tof32(view.color.x >> 16);
+	o.col.g = f16tof32(view.color.x);
+	o.col.b = f16tof32(view.color.y >> 16);
+	o.col.a = f16tof32(view.color.y);
+	o.conic = view.conicRadius.xyz;
+
+	float4 centerClipPos = view.pos;
+	bool behindCam = centerClipPos.w <= 0;
+    o.centerScreenPos = (centerClipPos.xy / centerClipPos.w * float2(0.5, 0.5*_ProjectionParams.x) + 0.5) * _ScreenParams.xy;
+
+	// two bits per vertex index to result in 0,1,2,1,3,2 from lowest:
+	// 0b1011'0110'0100
+	uint quadIndices = 0xB64;
+	uint idx = quadIndices >> (vtxID * 2);
+    float2 quadPos = float2(idx&1, (idx>>1)&1) * 2.0 - 1.0;
+
+	float radius = view.conicRadius.w;
+
+	float2 deltaScreenPos = quadPos * radius * 2 / _ScreenParams.xy;
+	o.vertex = centerClipPos;
+	o.vertex.xy += deltaScreenPos * centerClipPos.w;
+
+	if (behindCam)
+		o.vertex = 0.0 / 0.0;	
+	
+#else
 	SplatData splat = LoadSplatData(instID);
 
     float4 boxRot = splat.rot;
@@ -90,6 +127,7 @@ v2f vert (uint vtxID : SV_VertexID, uint instID : SV_InstanceID)
 
 	if (behindCam)
 		o.vertex = 0.0 / 0.0;
+#endif
     return o;
 }
 

--- a/Assets/GaussianSplatting/Shaders/RenderGaussianSplats.shader
+++ b/Assets/GaussianSplatting/Shaders/RenderGaussianSplats.shader
@@ -15,12 +15,7 @@ CGPROGRAM
 #pragma fragment frag
 #pragma require compute
 #pragma use_dxc metal vulkan
-#pragma multi_compile _ USE_VIEW_DATA
 
-// Metal DXC: 218ms
-// View splat data comp: 58ms
-
-#include "UnityCG.cginc"
 #include "GaussianSplatting.hlsl"
 
 StructuredBuffer<uint> _OrderBuffer;
@@ -33,19 +28,13 @@ struct v2f
     float4 vertex : SV_POSITION;
 };
 
-float _SplatScale;
-uint _SHOrder;
-
-#if USE_VIEW_DATA
 StructuredBuffer<SplatViewData> _SplatViewData;
-#endif
 
 v2f vert (uint vtxID : SV_VertexID, uint instID : SV_InstanceID)
 {
     v2f o;
     instID = _OrderBuffer[instID];
 	
-#if USE_VIEW_DATA
 	SplatViewData view = _SplatViewData[instID];
 	o.col.r = f16tof32(view.color.x >> 16);
 	o.col.g = f16tof32(view.color.x);
@@ -71,63 +60,7 @@ v2f vert (uint vtxID : SV_VertexID, uint instID : SV_InstanceID)
 
 	if (behindCam)
 		o.vertex = 0.0 / 0.0;	
-	
-#else
-	SplatData splat = LoadSplatData(instID);
 
-    float4 boxRot = splat.rot;
-    float3 boxSize = splat.scale;
-    boxSize *= _SplatScale;
-
-    float3x3 splatRotScaleMat = CalcMatrixFromRotationScale(boxRot, boxSize);
-	splatRotScaleMat = mul((float3x3)unity_ObjectToWorld, splatRotScaleMat);
-
-	float3 centerWorldPos = splat.pos;
-	centerWorldPos = mul(unity_ObjectToWorld, float4(centerWorldPos,1)).xyz;
-
-	float3 worldViewDir = _WorldSpaceCameraPos.xyz - centerWorldPos;
-	float3 objViewDir = mul((float3x3)unity_WorldToObject, worldViewDir);
-	objViewDir = normalize(objViewDir);
-
-    o.col.rgb = ShadeSH(splat.sh, objViewDir, _SHOrder);
-    o.col.a = splat.opacity;
-
-    float4 centerClipPos = mul(UNITY_MATRIX_VP, float4(centerWorldPos, 1));
-	bool behindCam = centerClipPos.w <= 0;
-    o.centerScreenPos = (centerClipPos.xy / centerClipPos.w * float2(0.5, 0.5*_ProjectionParams.x) + 0.5) * _ScreenParams.xy;
-
-    float3 cov3d0, cov3d1;
-    CalcCovariance3D(splatRotScaleMat, cov3d0, cov3d1);
-    float3 cov2d = CalcCovariance2D(centerWorldPos, cov3d0, cov3d1, UNITY_MATRIX_V, UNITY_MATRIX_P, _ScreenParams);
-
-	// conic
-    float det = cov2d.x * cov2d.z - cov2d.y * cov2d.y;
-	float3 conic = float3(cov2d.z, -cov2d.y, cov2d.x) * rcp(det);
-	o.conic = conic;
-
-	// make the quad in screenspace the required size to cover the extents
-	// of the 2D splat.
-	//@TODO: should be possible to orient the quad to cover an elongated
-	// splat tighter
-
-	// two bits per vertex index to result in 0,1,2,1,3,2 from lowest:
-	// 0b1011'0110'0100
-	uint quadIndices = 0xB64;
-	uint idx = quadIndices >> (vtxID * 2);
-    float2 quadPos = float2(idx&1, (idx>>1)&1) * 2.0 - 1.0;
-
-	float mid = 0.5f * (cov2d.x + cov2d.z);
-	float lambda1 = mid + sqrt(max(0.1f, mid * mid - det));
-	float lambda2 = mid - sqrt(max(0.1f, mid * mid - det));
-	float radius = ceil(3.f * sqrt(max(lambda1, lambda2)));
-
-	float2 deltaScreenPos = quadPos * radius * 2 / _ScreenParams.xy;
-	o.vertex = centerClipPos;
-	o.vertex.xy += deltaScreenPos * centerClipPos.w;
-
-	if (behindCam)
-		o.vertex = 0.0 / 0.0;
-#endif
     return o;
 }
 

--- a/Assets/GaussianSplatting/Shaders/SplatUtilities.compute
+++ b/Assets/GaussianSplatting/Shaders/SplatUtilities.compute
@@ -2,12 +2,12 @@
 
 #pragma kernel CSSetIndices
 #pragma kernel CSCalcDistances
+#pragma kernel CSCalcViewData
 
 #pragma use_dxc metal vulkan
 
 #include "GaussianSplatting.hlsl"
 
-Texture2D _SplatPositions;
 float4x4 _LocalToWorldMatrix;
 float4x4 _WorldToCameraMatrix;
 RWStructuredBuffer<uint> _SplatSortDistances;
@@ -54,3 +54,70 @@ void CSCalcDistances (uint3 id : SV_DispatchThreadID)
     uint mask = -((int)(fu >> 31)) | 0x80000000;
     _SplatSortDistances[idx] = fu ^ mask;
 }
+
+RWStructuredBuffer<SplatViewData> _SplatViewData;
+
+float4x4 _MatrixVP;
+float4x4 _MatrixV;
+float4x4 _MatrixP;
+float4x4 _MatrixObjectToWorld;
+float4x4 _MatrixWorldToObject;
+float4 _VecScreenParams;
+float4 _VecWorldSpaceCameraPos;
+
+float _SplatScale;
+uint _SHOrder;
+
+[numthreads(GROUP_SIZE,1,1)]
+void CSCalcViewData (uint3 id : SV_DispatchThreadID)
+{
+    uint idx = id.x;
+    if (idx >= _SplatCount)
+        return;
+
+    SplatData splat = LoadSplatData(idx);
+    SplatViewData view = (SplatViewData)0;
+    
+    float3 centerWorldPos = splat.pos;
+    
+    centerWorldPos = mul(_MatrixObjectToWorld, float4(centerWorldPos,1)).xyz;
+    float4 centerClipPos = mul(_MatrixVP, float4(centerWorldPos, 1));
+    view.pos = centerClipPos;
+    bool behindCam = centerClipPos.w <= 0;
+    if (!behindCam)
+    {
+        float4 boxRot = splat.rot;
+        float3 boxSize = splat.scale;
+        boxSize *= _SplatScale;
+
+        float3x3 splatRotScaleMat = CalcMatrixFromRotationScale(boxRot, boxSize);
+        splatRotScaleMat = mul((float3x3)_MatrixObjectToWorld, splatRotScaleMat);
+        
+        float3 cov3d0, cov3d1;
+        CalcCovariance3D(splatRotScaleMat, cov3d0, cov3d1);
+        float3 cov2d = CalcCovariance2D(centerWorldPos, cov3d0, cov3d1, _MatrixV, _MatrixP, _VecScreenParams);
+        
+        float det = cov2d.x * cov2d.z - cov2d.y * cov2d.y;
+
+        float mid = 0.5f * (cov2d.x + cov2d.z);
+        float lambda1 = mid + sqrt(max(0.1f, mid * mid - det));
+        float lambda2 = mid - sqrt(max(0.1f, mid * mid - det));
+        float radius = ceil(3.f * sqrt(max(lambda1, lambda2)));
+
+        float3 conic = float3(cov2d.z, -cov2d.y, cov2d.x) * rcp(det);
+        view.conicRadius = float4(conic, radius);
+
+        float3 worldViewDir = _VecWorldSpaceCameraPos.xyz - centerWorldPos;
+        float3 objViewDir = mul((float3x3)_MatrixWorldToObject, worldViewDir);
+        objViewDir = normalize(objViewDir);
+
+        half4 col;
+        col.rgb = ShadeSH(splat.sh, objViewDir, _SHOrder);
+        col.a = splat.opacity;
+        view.color.x = (f32tof16(col.r) << 16) | f32tof16(col.g);
+        view.color.y = (f32tof16(col.b) << 16) | f32tof16(col.a);
+    }
+    
+    _SplatViewData[idx] = view;
+}
+

--- a/readme.md
+++ b/readme.md
@@ -53,7 +53,7 @@ _That's it!_
 Wishlist that I may or might not do at some point:
 - [x] Make it respect the game object transform
 - [ ] Make rendering faster (actual tiled compute shader rasterizer)
-- [ ] Look at ways to make the data sets smaller (both on-disk and in-memory)
+- [x] Look at ways to make the data sets smaller (both on-disk and in-memory) ([blog post](https://aras-p.info/blog/2023/09/13/Making-Gaussian-Splats-smaller/))
 - [x] Integrate better with "the rest" of rendering that might be in the scene (BiRP)
 - [ ] Maybe look at making it work in URP/HDRP? Not sure yet
 - [x] Make sorting faster (bitonic -> FidelityFX radix sort)
@@ -66,14 +66,19 @@ My own blog posts about all this _(so far... not that many!)_:
 
 ## Performance numbers:
 
-"bicycle" scene from the paper, with 6.1M splats and first camera in there, rendering at 1200x800 resolution:
+"bicycle" scene from the paper, with 6.1M splats and first camera in there, rendering at 1200x797 resolution,
+at "Medium" asset quality level (273MB asset file):
+
 * Windows (NVIDIA RTX 3080 Ti):
   * Official SBIR viewer: 7.4ms (135FPS). 4.8GB VRAM usage.
-  * Unity, DX12 or Vulkan: 13.4ms (75FPS) - 10.1ms rendering, 3.3ms sorting. 2.1GB VRAM usage.
-  * Unity, DX11: 21.8ms (46FPS) - 9.9ms rendering, 11.9ms sorting.
+  * Unity, DX12 or Vulkan: 12.6ms (79FPS) - 9.4ms rendering, 2.4ms sorting, 0.7ms splat view calc. 1.2GB VRAM usage.
+  * Unity, DX11: 20.8ms (48FPS) - 9.6ms rendering, 10.4ms sorting, 0.6ms splat view calc.
 * Mac (Apple M1 Max):
-  * Unity, Metal: 80.6ms (12FPS) - with FidelityFX GPU sort.
-  * Unity, Metal: 108ms (9FPS) - with bitonic GPU sort.
+  * Unity, Metal: 55.0ms (18FPS).
+
+Besides the gaussian splat asset that is loaded into GPU memory, currently this also needs about 48 bytes of GPU memory
+per splat (for sorting, caching view dependent data etc.).
+
 
 ## External Code Used
 


### PR DESCRIPTION
...instead of computing it over and over again for each vertex of each quad that is being rendered.

This does not help on PC (RTX 3080Ti) much (13.4ms -> 12.6ms), but massively helps on Mac (M1), which had previously regressed in perf due to using all the data chunking & textures (from initial 80ms it had went up to 220ms). But now it's down to 55ms, so yay progress! And a lesson that vastly different GPU architectures have vastly different performance characteristics, who would have thunk.

Downside is that this now needs 40 bytes/splat of extra GPU memory to store the view data. Might be able to get that smaller, maybe.