### PR TITLE
Wrap editor scripts with UNITY_EDITOR directives

### DIFF
--- a/Assets/GaussianSplatting/Scripts/Editor/CaptureScreenshot.cs
+++ b/Assets/GaussianSplatting/Scripts/Editor/CaptureScreenshot.cs
@@ -1,3 +1,4 @@
+#if UNITY_EDITOR
 using UnityEditor;
 using UnityEngine;
 
@@ -19,3 +20,4 @@ public class CaptureScreenshot : MonoBehaviour
         Debug.Log($"Captured {path}");
     }
 }
+#endif

--- a/Assets/GaussianSplatting/Scripts/Editor/GaussianPlyImporter.cs
+++ b/Assets/GaussianSplatting/Scripts/Editor/GaussianPlyImporter.cs
@@ -1,3 +1,4 @@
+#if UNITY_EDITOR
 using System;
 using System.Collections.Generic;
 using System.IO;
@@ -997,3 +998,4 @@ public class GaussianPlyImporter : ScriptedImporter
         public float fy;
     }
 }
+#endif

--- a/Assets/GaussianSplatting/Scripts/Editor/GaussianPlyImporterEditor.cs
+++ b/Assets/GaussianSplatting/Scripts/Editor/GaussianPlyImporterEditor.cs
@@ -1,3 +1,4 @@
+#if UNITY_EDITOR
 using System;
 using System.IO;
 using UnityEditor;
@@ -144,3 +145,4 @@ public class GaussianPlyImporterEditor : AssetImporterEditor
         ApplyRevertGUI();
     }
 }
+#endif

--- a/Assets/GaussianSplatting/Scripts/Editor/GaussianSplatAssetEditor.cs
+++ b/Assets/GaussianSplatting/Scripts/Editor/GaussianSplatAssetEditor.cs
@@ -1,3 +1,4 @@
+#if UNITY_EDITOR
 using Unity.Collections.LowLevel.Unsafe;
 using UnityEditor;
 using UnityEngine;
@@ -47,3 +48,4 @@ public class GaussianSplatAssetEditor : Editor
         }
     }
 }
+#endif

--- a/Assets/GaussianSplatting/Scripts/Editor/GaussianSplatRendererEditor.cs
+++ b/Assets/GaussianSplatting/Scripts/Editor/GaussianSplatRendererEditor.cs
@@ -1,3 +1,4 @@
+#if UNITY_EDITOR
 using Unity.Mathematics;
 using UnityEditor;
 using UnityEngine;
@@ -50,3 +51,4 @@ public class GaussianSplatRendererEditor : Editor
         }
     }
 }
+#endif

--- a/Assets/GaussianSplatting/Scripts/Editor/GaussianSplatValidator.cs
+++ b/Assets/GaussianSplatting/Scripts/Editor/GaussianSplatValidator.cs
@@ -1,3 +1,4 @@
+#if UNITY_EDITOR
 using System.IO;
 using Unity.Burst;
 using Unity.Collections;
@@ -177,3 +178,4 @@ public class GaussianSplatValidator
         }
     }
 }
+#if UNITY_EDITOR


### PR DESCRIPTION
Wrapped all editor-specific scripts with `#if UNITY_EDITOR ... #endif` preprocessor directives to ensure they are excluded from non-editor builds