### PR TITLE
Subtract From Selection

### DIFF
--- a/package/Editor/GaussianSplatRendererEditor.cs
+++ b/package/Editor/GaussianSplatRendererEditor.cs
@@ -416,7 +416,7 @@ namespace GaussianSplatting.Editor
                         Rect rect = FromToRect(m_MouseStartDragPos, evt.mousePosition);
                         Vector2 rectMin = HandleUtility.GUIPointToScreenPixelCoordinate(rect.min);
                         Vector2 rectMax = HandleUtility.GUIPointToScreenPixelCoordinate(rect.max);
-                        gs.EditUpdateSelection(rectMin, rectMax, sceneView.camera);
+                        gs.EditUpdateSelection(rectMin, rectMax, sceneView.camera, evt.control);
                         GaussianSplatRendererEditor.RepaintAll();
                         evt.Use();
                     }

--- a/package/Runtime/GaussianSplatRenderer.cs
+++ b/package/Runtime/GaussianSplatRenderer.cs
@@ -302,6 +302,7 @@ namespace GaussianSplatting.Runtime
             public static readonly int VecWorldSpaceCameraPos = Shader.PropertyToID("_VecWorldSpaceCameraPos");
             public static readonly int SplatCutoutsCount = Shader.PropertyToID("_SplatCutoutsCount");
             public static readonly int SplatCutouts = Shader.PropertyToID("_SplatCutouts");
+            public static readonly int SelectionMode = Shader.PropertyToID("_SelectionMode");
         }
 
         [field: NonSerialized] public bool editModified { get; private set; }
@@ -698,7 +699,7 @@ namespace GaussianSplatting.Runtime
             Graphics.CopyBuffer(m_GpuSplatSelectedBuffer, m_GpuSplatSelectedInitBuffer);
         }
 
-        public void EditUpdateSelection(Vector2 rectMin, Vector2 rectMax, Camera cam)
+        public void EditUpdateSelection(Vector2 rectMin, Vector2 rectMax, Camera cam, bool subtract)
         {
             if (!EnsureEditingBuffers()) return;
 
@@ -726,6 +727,7 @@ namespace GaussianSplatting.Runtime
             cmb.SetComputeVectorParam(m_CSSplatUtilities, Props.VecWorldSpaceCameraPos, camPos);
 
             cmb.SetComputeVectorParam(m_CSSplatUtilities, "_SelectionRect", new Vector4(rectMin.x, rectMax.y, rectMax.x, rectMin.y));
+            cmb.SetComputeIntParam(m_CSSplatUtilities, Props.SelectionMode, subtract ? 0 : 1);
 
             DispatchUtilsAndExecute(cmb, KernelIndices.SelectionUpdate, m_Asset.m_SplatCount);
             UpdateEditCountsAndBounds();

--- a/package/Shaders/SplatUtilities.compute
+++ b/package/Shaders/SplatUtilities.compute
@@ -35,6 +35,7 @@ float4x4 _MatrixMV;
 float4x4 _MatrixP;
 float4 _VecScreenParams;
 float4 _VecWorldSpaceCameraPos;
+int _SelectionMode;
 
 RWStructuredBuffer<uint> _SplatSortDistances;
 RWStructuredBuffer<uint> _SplatSortKeys;
@@ -406,7 +407,10 @@ void CSSelectionUpdate (uint3 id : SV_DispatchThreadID)
     }
     uint wordIdx = idx / 32;
     uint bitIdx = idx & 31;
-    _SplatSelectedBits.InterlockedOr(wordIdx * 4, 1 << bitIdx);
+    if (_SelectionMode)
+        _SplatSelectedBits.InterlockedOr(wordIdx * 4, 1 << bitIdx); // +
+    else
+        _SplatSelectedBits.InterlockedAnd(wordIdx * 4, 1 << bitIdx); // -
 }
 
 


### PR DESCRIPTION
Fixes #69 😎
Hold `Ctrl` to subtract from the current selection. Uses `InterlockedAnd`.