### PR TITLE
Add DeviceRadixSort

### DIFF
--- a/package/Runtime/GpuSorting.cs
+++ b/package/Runtime/GpuSorting.cs
@@ -6,7 +6,7 @@ namespace GaussianSplatting.Runtime
 {
     // GPU (uint key, uint payload) 8 bit-LSD radix sort, using reduce-then-scan
     // Copyright Thomas Smith 2023, MIT license
-    // https://github.com/b0nes164/ShaderOneSweep this repo will be deprecated soon, see its readme!
+    // https://github.com/b0nes164/GPUSorting
 
     public class GpuSorting
     {
@@ -21,7 +21,6 @@ namespace GaussianSplatting.Runtime
 
         //Number of sorting passes required to sort a 32bit key, KEY_BITS / DEVICE_RADIX_SORT_BITS
         const uint DEVICE_RADIX_SORT_PASSES = 4;
-
 
         public struct Args
         {
@@ -116,10 +115,6 @@ namespace GaussianSplatting.Runtime
             public uint radixShift;                     // The radix shift value for the current pass
             public uint threadBlocks;                   // threadBlocks
             public uint padding0;                       // Padding - unused
-            public uint padding1;                       // Padding - unused
-            public uint padding2;                       // Padding - unused
-            public uint padding3;                       // Padding - unused
-            public uint padding4;                       // Padding - unused
         }
 
         public void Dispatch(CommandBuffer cmd, Args args)

--- a/package/Runtime/GpuSorting.cs
+++ b/package/Runtime/GpuSorting.cs
@@ -11,7 +11,7 @@ namespace GaussianSplatting.Runtime
     public class GpuSorting
     {
         //The size of a threadblock partition in the sort
-        const uint DEVICE_RADIX_SORT_PARTITION_SIZE = 7680;
+        const uint DEVICE_RADIX_SORT_PARTITION_SIZE = 3840;
 
         //The size of our radix in bits
         const uint DEVICE_RADIX_SORT_BITS = 8;

--- a/package/Shaders/DeviceRadixSort.hlsl
+++ b/package/Shaders/DeviceRadixSort.hlsl
@@ -1,8 +1,9 @@
 /******************************************************************************
  * Device Level 8-bit LSD Radix Sort using reduce then scan
- *
+ * 
  * SPDX-License-Identifier: MIT
- * Copyright Thomas Smith 12/6/2023
+ * Copyright Thomas Smith 2/13/2023
+ * https://github.com/b0nes164/GPUSorting
  *  
  *  Permission is hereby granted, free of charge, to any person obtaining a copy
  *  of this software and associated documentation files (the "Software"), to deal
@@ -22,36 +23,23 @@
  *  OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE
  *  SOFTWARE.
  ******************************************************************************/
-
 //General macros 
-#define PARTITION_SIZE      3840U   //size of a partition tile
+#define PART_SIZE       3840U       //size of a partition tile
 
-#define UPSWEEP_THREADS     128U    //The number of threads in a Upsweep threadblock
-#define SCAN_THREADS        128U    //The number of threads in a Scan threadblock
-#define DS_THREADS          256U    //The number of threads in a Downsweep threadblock
+#define US_DIM          128U        //The number of threads in a Upsweep threadblock
+#define SCAN_DIM        128U        //The number of threads in a Scan threadblock
+#define DS_DIM          256U        //The number of threads in a Downsweep threadblock
 
-#define RADIX               256U    //Number of digit bins
-#define RADIX_MASK          255U    //Mask of digit bins
-#define RADIX_LOG           8U      //log2(RADIX)
+#define RADIX           256U        //Number of digit bins
+#define RADIX_MASK      255U        //Mask of digit bins
+#define RADIX_LOG       8U          //log2(RADIX)
 
-//For smaller waves where bit packing is necessary
-#define HALF_RADIX          128U    
-#define HALF_MASK           127U
-
-#define WAVE_INDEX          (gtid.x / WaveGetLaneCount())                   //The wave that a thread belongs to
-#define PARTITION_START     (gid.x * PARTITION_SIZE)                        //The start of threadblock partition tile
+#define HALF_RADIX      128U        //For smaller waves where bit packing is necessary
+#define HALF_MASK       127U        // '' 
 
 //For the downsweep kernels
-#define DS_KEYS_PER_THREAD  15U                                             //The number of keys per thread in a Downsweep Threadblock
-#define MAX_DS_SMEM         4096U                                           //shared memory for downsweep kernel
-#define DS_WGE16_PART_SIZE  (DS_KEYS_PER_THREAD * WaveGetLaneCount())       //The size of a wave partition for wave size 16 or greater
-#define DS_WGE16_PART_START (WAVE_INDEX * DS_WGE16_PART_SIZE)               //The starting offset of a wave partition for wave size 16 or greater
-#define DS_WGE16_HISTS_SIZE (DS_THREADS / WaveGetLaneCount() * RADIX)       //The total size of all wave histograms in shared memory for wave size 16 or greater
-
-#define DS_WLT16_PART_SIZE  (DS_KEYS_PER_THREAD * WaveGetLaneCount() * serialIterations)    //The size of a "combined" wave partition for wave size less than 16
-#define DS_WLT16_PART_START ((WAVE_INDEX / serialIterations * DS_WLT16_PART_SIZE) + \
-                            ((WAVE_INDEX % serialIterations) * WaveGetLaneCount()))         //The starting offset of a "combined" wave partition for wave size less than 16
-#define DS_WLT16_HISTS_SIZE MAX_DS_SMEM                                                     //The total size of all wave histograms in shared memory for wave size less than 16
+#define DS_KEYS_PER_THREAD  15U     //The number of keys per thread in a Downsweep Threadblock
+#define MAX_DS_SMEM         4096U   //shared memory for downsweep kernel
 
 cbuffer cbParallelSort : register(b0)
 {
@@ -59,22 +47,87 @@ cbuffer cbParallelSort : register(b0)
     uint e_radixShift;
     uint e_threadBlocks;
     uint padding0;
-    uint padding1;
-    uint padding2;
-    uint padding3;
-    uint padding4;
 };
 
 RWStructuredBuffer<uint> b_sort;            //buffer to be sorted
-RWStructuredBuffer<uint> b_sortPayload;     //payload buffer
-RWStructuredBuffer<uint> b_alt;             //double buffer
+RWStructuredBuffer<uint> b_alt;             //payload buffer
+RWStructuredBuffer<uint> b_sortPayload;     //double buffer
 RWStructuredBuffer<uint> b_altPayload;      //double buffer payload
-RWStructuredBuffer<uint> b_globalHist;      //buffer holding device level offsets for each binning pass
-RWStructuredBuffer<uint> b_passHist;        //buffer used to store reduced sums of partition tiles
+RWStructuredBuffer<uint> b_globalHist;      //buffer holding global device level offsets 
+                                            //for each digit during a binning pass
+RWStructuredBuffer<uint> b_passHist;        //buffer used to store device level offsets for 
+                                            //each partition tile for each digit during a binning pass
 
-groupshared uint g_upsweepHist[RADIX * 2];  //Shared memory for upsweep
-groupshared uint g_scanMem[SCAN_THREADS];   //Shared memory for the scan
-groupshared uint g_dsMem[MAX_DS_SMEM];      //Shared memory for the downsweep
+groupshared uint g_us[RADIX * 2];           //Shared memory for upsweep kernel
+groupshared uint g_scan[SCAN_DIM];          //Shared memory for the scan kernel
+groupshared uint g_ds[MAX_DS_SMEM];         //Shared memory for the downsweep kernel
+
+inline uint getWaveIndex(uint gtid)
+{
+    return gtid / WaveGetLaneCount();
+}
+
+inline uint ExtractDigit(uint key)
+{
+    return key >> e_radixShift & RADIX_MASK;
+}
+
+inline uint ExtractPackedIndex(uint key)
+{
+    return key >> (e_radixShift + 1) & HALF_MASK;
+}
+
+inline uint ExtractPackedShift(uint key)
+{
+    return (key >> e_radixShift & 1) ? 16 : 0;
+}
+
+inline uint ExtractPackedValue(uint packed, uint key)
+{
+    return packed >> ExtractPackedShift(key) & 0xffff;
+}
+
+inline uint SubPartSizeWGE16()
+{
+    return DS_KEYS_PER_THREAD * WaveGetLaneCount();
+}
+
+inline uint SharedOffsetWGE16(uint gtid)
+{
+    return WaveGetLaneIndex() + getWaveIndex(gtid) * SubPartSizeWGE16();
+}
+
+inline uint DeviceOffsetWGE16(uint gtid, uint gid)
+{
+    return SharedOffsetWGE16(gtid) + gid * PART_SIZE;
+}
+
+inline uint SubPartSizeWLT16(uint _serialIterations)
+{
+    return DS_KEYS_PER_THREAD * WaveGetLaneCount() * _serialIterations;
+}
+
+inline uint SharedOffsetWLT16(uint gtid, uint _serialIterations)
+{
+    return WaveGetLaneIndex() +
+        (getWaveIndex(gtid) / _serialIterations * SubPartSizeWLT16(_serialIterations)) +
+        (getWaveIndex(gtid) % _serialIterations * WaveGetLaneCount());
+}
+
+inline uint DeviceOffsetWLT16(uint gtid, uint gid, uint _serialIterations)
+{
+    return SharedOffsetWLT16(gtid, _serialIterations) + gid * PART_SIZE;
+}
+
+inline uint WaveHistsSizeWGE16()
+{
+    return DS_DIM / WaveGetLaneCount() * RADIX;
+}
+
+inline uint WaveHistsSizeWLT16()
+{
+    return MAX_DS_SMEM;
+}
 
 //Clear the global histogram, as we will be adding to it atomically
 [numthreads(1024, 1, 1)]
@@ -83,57 +136,54 @@ void InitDeviceRadixSort(int3 id : SV_DispatchThreadID)
     b_globalHist[id.x] = 0;
 }
 
-[numthreads(UPSWEEP_THREADS, 1, 1)]
+[numthreads(US_DIM, 1, 1)]
 void Upsweep(uint3 gtid : SV_GroupThreadID, uint3 gid : SV_GroupID)
 {
     //clear shared memory
-    {
-        const uint histsEnd = RADIX * 2;
-        for (uint i = gtid.x; i < histsEnd; i += UPSWEEP_THREADS)
-            g_upsweepHist[i] = 0;
-    }
+    const uint histsEnd = RADIX * 2;
+    for (uint i = gtid.x; i < histsEnd; i += US_DIM)
+        g_us[i] = 0;
     GroupMemoryBarrierWithGroupSync();
 
     //histogram, 64 threads to a histogram
-    {
-        const uint radixShift = e_radixShift;
-        const uint offset = gtid.x / 64 * RADIX;
-        const uint partitionEnd = gid.x == e_threadBlocks - 1 ? e_numKeys : (gid.x + 1) * PARTITION_SIZE;
-        for (uint i = gtid.x + PARTITION_START; i < partitionEnd; i += UPSWEEP_THREADS)
-            InterlockedAdd(g_upsweepHist[(b_sort[i] >> radixShift & RADIX_MASK) + offset], 1);
-    }
+    const uint histOffset = gtid.x / 64 * RADIX;
+    const uint partitionEnd = gid.x == e_threadBlocks - 1 ?
+        e_numKeys : (gid.x + 1) * PART_SIZE;
+    for (uint i = gtid.x + gid.x * PART_SIZE; i < partitionEnd; i += US_DIM)
+        InterlockedAdd(g_us[ExtractDigit(b_sort[i]) + histOffset], 1);
     GroupMemoryBarrierWithGroupSync();
     
     //reduce and pass to tile histogram
+    for (uint i = gtid.x; i < RADIX; i += US_DIM)
     {
-        const uint threadBlocks = e_threadBlocks;
-        for (uint i = gtid.x; i < RADIX; i += UPSWEEP_THREADS)
-        {
-            g_upsweepHist[i] += g_upsweepHist[i + RADIX];
-            b_passHist[i * threadBlocks + gid.x] = g_upsweepHist[i];
-        }
+        g_us[i] += g_us[i + RADIX];
+        b_passHist[i * e_threadBlocks + gid.x] = g_us[i];
     }
     
     //Larger 16 or greater can perform a more elegant scan because 16 * 16 = 256
     if (WaveGetLaneCount() >= 16)
     {
-        for (uint i = gtid.x; i < RADIX; i += UPSWEEP_THREADS)
-            g_upsweepHist[i] += WavePrefixSum(g_upsweepHist[i]);
+        for (uint i = gtid.x; i < RADIX; i += US_DIM)
+            g_us[i] += WavePrefixSum(g_us[i]);
         GroupMemoryBarrierWithGroupSync();
         
         if (gtid.x < (RADIX / WaveGetLaneCount()))
-            g_upsweepHist[(gtid.x + 1) * WaveGetLaneCount() - 1] += WavePrefixSum(g_upsweepHist[(gtid.x + 1) * WaveGetLaneCount() - 1]);
+        {
+            g_us[(gtid.x + 1) * WaveGetLaneCount() - 1] +=
+                WavePrefixSum(g_us[(gtid.x + 1) * WaveGetLaneCount() - 1]);
+        }
         GroupMemoryBarrierWithGroupSync();
         
         //atomically add to global histogram
-        const uint offset = e_radixShift << 5;
+        const uint deviceOffset = e_radixShift << 5;
         const uint laneMask = WaveGetLaneCount() - 1;
         const uint circularLaneShift = WaveGetLaneIndex() + 1 & laneMask;
-        for (uint i = gtid.x; i < RADIX; i += UPSWEEP_THREADS)
+        for (uint i = gtid.x; i < RADIX; i += US_DIM)
         {
             const uint index = circularLaneShift + (i & ~laneMask);
-            InterlockedAdd(b_globalHist[index + offset], (WaveGetLaneIndex() != laneMask ? g_upsweepHist[i] : 0) +
-                (i >= WaveGetLaneCount() ? WaveReadLaneAt(g_upsweepHist[i - 1], 0) : 0));
+            InterlockedAdd(b_globalHist[index + deviceOffset],
+                (WaveGetLaneIndex() != laneMask ? g_us[i] : 0) +
+                (i >= WaveGetLaneCount() ? WaveReadLaneAt(g_us[i - 1], 0) : 0));
         }
     }
     
@@ -141,11 +191,14 @@ void Upsweep(uint3 gtid : SV_GroupThreadID, uint3 gid : SV_GroupID)
     if (WaveGetLaneCount() < 16)
     {
         const uint deviceOffset = e_radixShift << 5;
-        for (uint i = gtid.x; i < RADIX; i += UPSWEEP_THREADS)
-            g_upsweepHist[i] += WavePrefixSum(g_upsweepHist[i]);
+        for (uint i = gtid.x; i < RADIX; i += US_DIM)
+            g_us[i] += WavePrefixSum(g_us[i]);
         
         if (gtid.x < WaveGetLaneCount())
-            InterlockedAdd(b_globalHist[gtid.x + deviceOffset], gtid.x ? g_upsweepHist[gtid.x - 1] : 0);
+        {
+            InterlockedAdd(b_globalHist[gtid.x + deviceOffset],
+                gtid.x ? g_us[gtid.x - 1] : 0);
+        }
         GroupMemoryBarrierWithGroupSync();
         
         const uint laneLog = countbits(WaveGetLaneCount() - 1);
@@ -153,24 +206,30 @@ void Upsweep(uint3 gtid : SV_GroupThreadID, uint3 gid : SV_GroupID)
         uint j = WaveGetLaneCount();
         for (; j < (RADIX >> 1); j <<= laneLog)
         {
-            for (uint i = gtid.x; i < (RADIX >> offset); i += UPSWEEP_THREADS)
-                g_upsweepHist[((i + 1) << offset) - 1] += WavePrefixSum(g_upsweepHist[((i + 1) << offset) - 1]);
+            for (uint i = gtid.x; i < (RADIX >> offset); i += US_DIM)
+            {
+                g_us[((i + 1) << offset) - 1] +=
+                    WavePrefixSum(g_us[((i + 1) << offset) - 1]);
+            }
             GroupMemoryBarrierWithGroupSync();
             
-            for (uint i = gtid.x + j; i < RADIX; i += UPSWEEP_THREADS)
+            for (uint i = gtid.x + j; i < RADIX; i += US_DIM)
             {
                 if ((i & ((j << laneLog) - 1)) >= j)
                 {
                     if (i < (j << laneLog))
                     {
                         InterlockedAdd(b_globalHist[i + deviceOffset],
-                            WaveReadLaneAt(g_upsweepHist[((i >> offset) << offset) - 1], 0) +
-                            ((i & (j - 1)) ? g_upsweepHist[i - 1] : 0));
+                            WaveReadLaneAt(g_us[((i >> offset) << offset) - 1], 0) +
+                            ((i & (j - 1)) ? g_us[i - 1] : 0));
                     }
                     else
                     {
                         if ((i + 1) & (j - 1))
-                            g_upsweepHist[i] += WaveReadLaneAt(g_upsweepHist[((i >> offset) << offset) - 1], 0);
+                        {
+                            g_us[i] +=
+                                WaveReadLaneAt(g_us[((i >> offset) << offset) - 1], 0);
+                        }
                     }
                 }
             }
@@ -178,17 +237,17 @@ void Upsweep(uint3 gtid : SV_GroupThreadID, uint3 gid : SV_GroupID)
         }
         GroupMemoryBarrierWithGroupSync();
         
-        for (uint i = gtid.x + j; i < RADIX; i += UPSWEEP_THREADS)
+        for (uint i = gtid.x + j; i < RADIX; i += US_DIM)
         {
             InterlockedAdd(b_globalHist[i + deviceOffset],
-                WaveReadLaneAt(g_upsweepHist[((i >> offset) << offset) - 1], 0) +
-                ((i & (j - 1)) ? g_upsweepHist[i - 1] : 0));
+                WaveReadLaneAt(g_us[((i >> offset) << offset) - 1], 0) +
+                ((i & (j - 1)) ? g_us[i - 1] : 0));
         }
     }
 }
 
 //Scan along the spine of the upsweep
-[numthreads(SCAN_THREADS, 1, 1)]
+[numthreads(SCAN_DIM, 1, 1)]
 void Scan(uint3 gtid : SV_GroupThreadID, uint3 gid : SV_GroupID)
 {
     if (WaveGetLaneCount() >= 16)
@@ -196,82 +255,98 @@ void Scan(uint3 gtid : SV_GroupThreadID, uint3 gid : SV_GroupID)
         uint aggregate = 0;
         const uint laneMask = WaveGetLaneCount() - 1;
         const uint circularLaneShift = WaveGetLaneIndex() + 1 & laneMask;
-        const uint partionsEnd = e_threadBlocks / SCAN_THREADS * SCAN_THREADS;
+        const uint partionsEnd = e_threadBlocks / SCAN_DIM * SCAN_DIM;
         const uint offset = gid.x * e_threadBlocks;
         uint i = gtid.x;
-        for (; i < partionsEnd; i += SCAN_THREADS)
+        for (; i < partionsEnd; i += SCAN_DIM)
         {
-            g_scanMem[gtid.x] = b_passHist[i + offset];
-            g_scanMem[gtid.x] += WavePrefixSum(g_scanMem[gtid.x]);
+            g_scan[gtid.x] = b_passHist[i + offset];
+            g_scan[gtid.x] += WavePrefixSum(g_scan[gtid.x]);
             GroupMemoryBarrierWithGroupSync();
             
-            if (gtid.x < SCAN_THREADS / WaveGetLaneCount())
-                g_scanMem[(gtid.x + 1) * WaveGetLaneCount() - 1] += WavePrefixSum(g_scanMem[(gtid.x + 1) * WaveGetLaneCount() - 1]);
+            if (gtid.x < SCAN_DIM / WaveGetLaneCount())
+            {
+                g_scan[(gtid.x + 1) * WaveGetLaneCount() - 1] +=
+                    WavePrefixSum(g_scan[(gtid.x + 1) * WaveGetLaneCount() - 1]);
+            }
             GroupMemoryBarrierWithGroupSync();
             
-            b_passHist[circularLaneShift + (i & ~laneMask) + offset] = (WaveGetLaneIndex() != laneMask ? g_scanMem[gtid.x] : 0) +
-                (gtid.x >= WaveGetLaneCount() ? WaveReadLaneAt(g_scanMem[gtid.x - 1], 0) : 0) + aggregate;
+            b_passHist[circularLaneShift + (i & ~laneMask) + offset] =
+                (WaveGetLaneIndex() != laneMask ? g_scan[gtid.x] : 0) +
+                (gtid.x >= WaveGetLaneCount() ?
+                WaveReadLaneAt(g_scan[gtid.x - 1], 0) : 0) +
+                aggregate;
 
-            aggregate += g_scanMem[SCAN_THREADS - 1];
+            aggregate += g_scan[SCAN_DIM - 1];
             GroupMemoryBarrierWithGroupSync();
         }
         
         //partial
         if (i < e_threadBlocks)
-            g_scanMem[gtid.x] = b_passHist[offset + i];
-        g_scanMem[gtid.x] += WavePrefixSum(g_scanMem[gtid.x]);
+            g_scan[gtid.x] = b_passHist[offset + i];
+        g_scan[gtid.x] += WavePrefixSum(g_scan[gtid.x]);
         GroupMemoryBarrierWithGroupSync();
             
-        if (gtid.x < SCAN_THREADS / WaveGetLaneCount())
-            g_scanMem[(gtid.x + 1) * WaveGetLaneCount() - 1] += WavePrefixSum(g_scanMem[(gtid.x + 1) * WaveGetLaneCount() - 1]);
+        if (gtid.x < SCAN_DIM / WaveGetLaneCount())
+        {
+            g_scan[(gtid.x + 1) * WaveGetLaneCount() - 1] +=
+                WavePrefixSum(g_scan[(gtid.x + 1) * WaveGetLaneCount() - 1]);
+        }
         GroupMemoryBarrierWithGroupSync();
         
         const uint index = circularLaneShift + (i & ~laneMask);
         if (index < e_threadBlocks)
         {
-            b_passHist[index + offset] = (WaveGetLaneIndex() != laneMask ? g_scanMem[gtid.x] : 0) +
-                (gtid.x >= WaveGetLaneCount() ? g_scanMem[(gtid.x & ~laneMask) - 1] : 0) + aggregate;
+            b_passHist[index + offset] = (WaveGetLaneIndex() != laneMask ? g_scan[gtid.x] : 0) +
+                (gtid.x >= WaveGetLaneCount() ? g_scan[(gtid.x & ~laneMask) - 1] : 0) + aggregate;
         }
     }
 
     if (WaveGetLaneCount() < 16)
     {
         uint aggregate = 0;
-        const uint partitions = e_threadBlocks / SCAN_THREADS;
+        const uint partitions = e_threadBlocks / SCAN_DIM;
         const uint deviceOffset = gid.x * e_threadBlocks;
         const uint laneLog = countbits(WaveGetLaneCount() - 1);
         
         uint k = 0;
         for (; k < partitions; ++k)
         {
-            g_scanMem[gtid.x] = b_passHist[gtid.x + k * SCAN_THREADS + deviceOffset];
-            g_scanMem[gtid.x] += WavePrefixSum(g_scanMem[gtid.x]);
+            g_scan[gtid.x] = b_passHist[gtid.x + k * SCAN_DIM + deviceOffset];
+            g_scan[gtid.x] += WavePrefixSum(g_scan[gtid.x]);
             
             if (gtid.x < WaveGetLaneCount())
-                b_passHist[gtid.x + k * SCAN_THREADS + deviceOffset] = (gtid.x ? g_scanMem[gtid.x - 1] : 0) + aggregate;
+            {
+                b_passHist[gtid.x + k * SCAN_DIM + deviceOffset] =
+                    (gtid.x ? g_scan[gtid.x - 1] : 0) + aggregate;
+            }
             GroupMemoryBarrierWithGroupSync();
             
             uint offset = laneLog;
             uint j = WaveGetLaneCount();
-            for (; j < (SCAN_THREADS >> 1); j <<= laneLog)
+            for (; j < (SCAN_DIM >> 1); j <<= laneLog)
             {
-                for (uint i = gtid.x; i < (SCAN_THREADS >> offset); i += SCAN_THREADS)
-                    g_scanMem[((i + 1) << offset) - 1] += WavePrefixSum(g_scanMem[((i + 1) << offset) - 1]);
+                for (uint i = gtid.x; i < (SCAN_DIM >> offset); i += SCAN_DIM)
+                {
+                    g_scan[((i + 1) << offset) - 1] +=
+                        WavePrefixSum(g_scan[((i + 1) << offset) - 1]);
+                }
                 GroupMemoryBarrierWithGroupSync();
             
-                for (uint i = gtid.x + j; i < SCAN_THREADS; i += SCAN_THREADS)
+                if ((gtid.x & ((j << laneLog) - 1)) >= j)
                 {
-                    if ((i & ((j << laneLog) - 1)) >= j)
+                    if (gtid.x < (j << laneLog))
                     {
-                        if (i < (j << laneLog))
+                        b_passHist[gtid.x + k * SCAN_DIM + deviceOffset] =
+                            WaveReadLaneAt(g_scan[((gtid.x >> offset) << offset) - 1], 0) +
+                            ((gtid.x & (j - 1)) ? g_scan[gtid.x - 1] : 0) + aggregate;
+                    }
+                    else
+                    {
+                        if ((gtid.x + 1) & (j - 1))
                         {
-                            b_passHist[i + k * SCAN_THREADS + deviceOffset] = WaveReadLaneAt(g_scanMem[((i >> offset) << offset) - 1], 0) +
-                                ((i & (j - 1)) ? g_scanMem[i - 1] : 0) + aggregate;
-                        }
-                        else
-                        {
-                            if ((i + 1) & (j - 1))
-                                g_scanMem[i] += WaveReadLaneAt(g_scanMem[((i >> offset) << offset) - 1], 0);
+                            g_scan[gtid.x] +=
+                                WaveReadLaneAt(g_scan[((gtid.x >> offset) << offset) - 1], 0);
                         }
                     }
                 }
@@ -279,48 +354,57 @@ void Scan(uint3 gtid : SV_GroupThreadID, uint3 gid : SV_GroupID)
             }
             GroupMemoryBarrierWithGroupSync();
         
-            for (uint i = gtid.x + j; i < SCAN_THREADS; i += SCAN_THREADS)
+            for (uint i = gtid.x + j; i < SCAN_DIM; i += SCAN_DIM)
             {
-                b_passHist[i + k * SCAN_THREADS + deviceOffset] = WaveReadLaneAt(g_scanMem[((i >> offset) << offset) - 1], 0) +
-                            ((i & (j - 1)) ? g_scanMem[i - 1] : 0) + aggregate;
+                b_passHist[i + k * SCAN_DIM + deviceOffset] =
+                    WaveReadLaneAt(g_scan[((i >> offset) << offset) - 1], 0) +
+                    ((i & (j - 1)) ? g_scan[i - 1] : 0) + aggregate;
             }
             
-            aggregate += WaveReadLaneAt(g_scanMem[SCAN_THREADS - 1], 0) + WaveReadLaneAt(g_scanMem[(((SCAN_THREADS - 1) >> offset) << offset) - 1], 0);
+            aggregate += WaveReadLaneAt(g_scan[SCAN_DIM - 1], 0) +
+                WaveReadLaneAt(g_scan[(((SCAN_DIM - 1) >> offset) << offset) - 1], 0);
             GroupMemoryBarrierWithGroupSync();
         }
         
         //partial
-        const uint finalPartSize = e_threadBlocks - k * SCAN_THREADS;
+        const uint finalPartSize = e_threadBlocks - k * SCAN_DIM;
         if (gtid.x < finalPartSize)
         {
-            g_scanMem[gtid.x] = b_passHist[gtid.x + k * SCAN_THREADS + deviceOffset];
-            g_scanMem[gtid.x] += WavePrefixSum(g_scanMem[gtid.x]);
+            g_scan[gtid.x] = b_passHist[gtid.x + k * SCAN_DIM + deviceOffset];
+            g_scan[gtid.x] += WavePrefixSum(g_scan[gtid.x]);
             
             if (gtid.x < WaveGetLaneCount())
-                b_passHist[gtid.x + k * SCAN_THREADS + deviceOffset] = (gtid.x ? g_scanMem[gtid.x - 1] : 0) + aggregate;
+            {
+                b_passHist[gtid.x + k * SCAN_DIM + deviceOffset] =
+                    (gtid.x ? g_scan[gtid.x - 1] : 0) + aggregate;
+            }
         }
         GroupMemoryBarrierWithGroupSync();
         
         uint offset = laneLog;
         for (uint j = WaveGetLaneCount(); j < finalPartSize; j <<= laneLog)
         {
-            for (uint i = gtid.x; i < (finalPartSize >> offset); i += SCAN_THREADS)
-                g_scanMem[((i + 1) << offset) - 1] += WavePrefixSum(g_scanMem[((i + 1) << offset) - 1]);
+            for (uint i = gtid.x; i < (finalPartSize >> offset); i += SCAN_DIM)
+            {
+                g_scan[((i + 1) << offset) - 1] +=
+                    WavePrefixSum(g_scan[((i + 1) << offset) - 1]);
+            }
             GroupMemoryBarrierWithGroupSync();
             
-            for (uint i = gtid.x + j; i < finalPartSize; i += SCAN_THREADS)
+            if ((gtid.x & ((j << laneLog) - 1)) >= j && gtid.x < finalPartSize)
             {
-                if ((i & ((j << laneLog) - 1)) >= j)
+                if (gtid.x < (j << laneLog))
                 {
-                    if (i < (j << laneLog))
+                    b_passHist[gtid.x + k * SCAN_DIM + deviceOffset] =
+                        WaveReadLaneAt(g_scan[((gtid.x >> offset) << offset) - 1], 0) +
+                        ((gtid.x & (j - 1)) ? g_scan[gtid.x - 1] : 0) + aggregate;
+                }
+                else
+                {
+                    if ((gtid.x + 1) & (j - 1))
                     {
-                        b_passHist[i + k * SCAN_THREADS + deviceOffset] = WaveReadLaneAt(g_scanMem[((i >> offset) << offset) - 1], 0) +
-                            ((i & (j - 1)) ? g_scanMem[i - 1] : 0) + aggregate;
-                    }
-                    else
-                    {
-                        if ((i + 1) & (j - 1))
-                            g_scanMem[i] += WaveReadLaneAt(g_scanMem[((i >> offset) << offset) - 1], 0);
+                        g_scan[gtid.x] +=
+                            WaveReadLaneAt(g_scan[((gtid.x >> offset) << offset) - 1], 0);
                     }
                 }
             }
@@ -329,303 +413,315 @@ void Scan(uint3 gtid : SV_GroupThreadID, uint3 gid : SV_GroupID)
     }
 }
 
-[numthreads(DS_THREADS, 1, 1)]
+[numthreads(DS_DIM, 1, 1)]
 void Downsweep(uint3 gtid : SV_GroupThreadID, uint3 gid : SV_GroupID)
 {
     if (gid.x < e_threadBlocks - 1)
     {
         uint keys[DS_KEYS_PER_THREAD];
         uint offsets[DS_KEYS_PER_THREAD];
-        uint exclusiveWaveReduction;
         
         if (WaveGetLaneCount() >= 16)
         {
             //Load keys into registers
             [unroll]
-            for (uint i = 0, t = WaveGetLaneIndex() + DS_WGE16_PART_START + PARTITION_START; i < DS_KEYS_PER_THREAD; ++i, t += WaveGetLaneCount())
+            for (uint i = 0, t = DeviceOffsetWGE16(gtid.x, gid.x);
+                 i < DS_KEYS_PER_THREAD;
+                 ++i, t += WaveGetLaneCount())
+            {
                 keys[i] = b_sort[t];
+            }
             
             //Clear histogram memory
-            {
-                const uint downsweepHists = DS_WGE16_HISTS_SIZE;
-                for (uint i = gtid.x; i < downsweepHists; i += DS_THREADS)
-                    g_dsMem[i] = 0;
-            }
+            for (uint i = gtid.x; i < WaveHistsSizeWGE16(); i += DS_DIM)
+                g_ds[i] = 0;
             GroupMemoryBarrierWithGroupSync();
 
             //Warp Level Multisplit
+            const uint waveParts = (WaveGetLaneCount() + 31) / 32;
+            [unroll]
+            for (uint i = 0; i < DS_KEYS_PER_THREAD; ++i)
             {
-                const uint waveParts = (WaveGetLaneCount() + 31) / 32;
-                uint4 waveFlags;
-            
-                [unroll]
-                for (uint i = 0; i < DS_KEYS_PER_THREAD; ++i)
-                {
-                    waveFlags = (WaveGetLaneCount() & 31) ? (1U << WaveGetLaneCount()) - 1 : 0xffffffff;
+                uint4 waveFlags = (WaveGetLaneCount() & 31) ?
+                    (1U << WaveGetLaneCount()) - 1 : 0xffffffff;
 
-                    for (uint k = e_radixShift; k < e_radixShift + RADIX_LOG; ++k)
-                    {
-                        const bool t = keys[i] >> k & 1;
-                        const uint4 ballot = WaveActiveBallot(t);
-                        for (int wavePart = 0; wavePart < waveParts; ++wavePart)
-                            waveFlags[wavePart] &= (t ? 0 : 0xffffffff) ^ ballot[wavePart];
-                    }
-                
-                    uint bits = 0;
-                    for (uint wavePart = 0; wavePart < waveParts; ++wavePart)
-                    {
-                        //%lanemask_le
-                        if (WaveGetLaneIndex() >= wavePart * 32)
-                        {
-                            const uint leMask = WaveGetLaneIndex() >= ((wavePart + 1) * 32) - 1 ? 0xffffffff :
-                            (1U << ((WaveGetLaneIndex() & 31) + 1)) - 1;
-                            bits += countbits(waveFlags[wavePart] & leMask);
-                        }
-                    }
-                    
-                    const uint index = (keys[i] >> e_radixShift & RADIX_MASK) + (WAVE_INDEX * RADIX);
-                    offsets[i] = g_dsMem[index] + bits - 1;
-                    
-                    GroupMemoryBarrierWithGroupSync();
-                    if (bits == 1)
-                    {
-                        for (uint wavePart = 0; wavePart < waveParts; ++wavePart)
-                            g_dsMem[index] += countbits(waveFlags[wavePart]);
-                    }
-                    GroupMemoryBarrierWithGroupSync();
+                [unroll]
+                for (uint k = 0; k < RADIX_LOG; ++k)
+                {
+                    const bool t = keys[i] >> (k + e_radixShift) & 1;
+                    const uint4 ballot = WaveActiveBallot(t);
+                    for (int wavePart = 0; wavePart < waveParts; ++wavePart)
+                        waveFlags[wavePart] &= (t ? 0 : 0xffffffff) ^ ballot[wavePart];
                 }
+                    
+                uint bits = 0;
+                for (uint wavePart = 0; wavePart < waveParts; ++wavePart)
+                {
+                    if (WaveGetLaneIndex() >= wavePart * 32)
+                    {
+                        const uint ltMask = WaveGetLaneIndex() >= (wavePart + 1) * 32 ?
+                            0xffffffff : (1U << (WaveGetLaneIndex() & 31)) - 1;
+                        bits += countbits(waveFlags[wavePart] & ltMask);
+                    }
+                }
+                    
+                const uint index = ExtractDigit(keys[i]) + (getWaveIndex(gtid.x) * RADIX);
+                offsets[i] = g_ds[index] + bits;
+                    
+                GroupMemoryBarrierWithGroupSync();
+                if (bits == 0)
+                {
+                    for (uint wavePart = 0; wavePart < waveParts; ++wavePart)
+                        g_ds[index] += countbits(waveFlags[wavePart]);
+                }
+                GroupMemoryBarrierWithGroupSync();
             }
+            GroupMemoryBarrierWithGroupSync();
             
             //inclusive/exclusive prefix sum up the histograms
             //followed by exclusive prefix sum across the reductions
+            uint reduction = g_ds[gtid.x];
+            for (uint i = gtid.x + RADIX; i < WaveHistsSizeWGE16(); i += RADIX)
             {
-                uint reduction;
-                if (gtid.x < RADIX)
-                {
-                    reduction = g_dsMem[gtid.x];
-                    for (uint i = gtid.x + RADIX; i < DS_WGE16_HISTS_SIZE; i += RADIX)
-                    {
-                        reduction += g_dsMem[i];
-                        g_dsMem[i] = reduction - g_dsMem[i];
-                    }
-                    reduction += WavePrefixSum(reduction);
-                }
-                GroupMemoryBarrierWithGroupSync();
-
-                if (gtid.x < RADIX)
-                {
-                    const uint laneMask = WaveGetLaneCount() - 1;
-                    g_dsMem[((WaveGetLaneIndex() + 1) & laneMask) + (gtid.x & ~laneMask)] = reduction;
-                }
-                GroupMemoryBarrierWithGroupSync();
-                
-                if (gtid.x < RADIX / WaveGetLaneCount())
-                    g_dsMem[gtid.x * WaveGetLaneCount()] = WavePrefixSum(g_dsMem[gtid.x * WaveGetLaneCount()]);
-                GroupMemoryBarrierWithGroupSync();
-                
-                if (gtid.x < RADIX && WaveGetLaneIndex())
-                    g_dsMem[gtid.x] += WaveReadLaneAt(g_dsMem[gtid.x - 1], 1);
+                reduction += g_ds[i];
+                g_ds[i] = reduction - g_ds[i];
             }
+            
+            reduction += WavePrefixSum(reduction);
+            GroupMemoryBarrierWithGroupSync();
+
+            const uint laneMask = WaveGetLaneCount() - 1;
+            g_ds[((WaveGetLaneIndex() + 1) & laneMask) + (gtid.x & ~laneMask)] = reduction;
+            GroupMemoryBarrierWithGroupSync();
+                
+            if (gtid.x < RADIX / WaveGetLaneCount())
+            {
+                g_ds[gtid.x * WaveGetLaneCount()] =
+                    WavePrefixSum(g_ds[gtid.x * WaveGetLaneCount()]);
+            }
+            GroupMemoryBarrierWithGroupSync();
+                
+            if (WaveGetLaneIndex())
+                g_ds[gtid.x] += WaveReadLaneAt(g_ds[gtid.x - 1], 1);
             GroupMemoryBarrierWithGroupSync();
         
             //Update offsets
             if (gtid.x >= WaveGetLaneCount())
             {
-                const uint t = WAVE_INDEX * RADIX;
+                const uint t = getWaveIndex(gtid.x) * RADIX;
                 [unroll]
                 for (uint i = 0; i < DS_KEYS_PER_THREAD; ++i)
                 {
-                    const uint t2 = keys[i] >> e_radixShift & RADIX_MASK;
-                    offsets[i] += g_dsMem[t2 + t] + g_dsMem[t2];
+                    const uint t2 = ExtractDigit(keys[i]);
+                    offsets[i] += g_ds[t2 + t] + g_ds[t2];
                 }
             }
             else
             {
                 [unroll]
                 for (uint i = 0; i < DS_KEYS_PER_THREAD; ++i)
-                    offsets[i] += g_dsMem[keys[i] >> e_radixShift & RADIX_MASK];
+                    offsets[i] += g_ds[ExtractDigit(keys[i])];
             }
             
             //take advantage of barrier
-            exclusiveWaveReduction = g_dsMem[gtid.x];
+            const uint exclusiveWaveReduction = g_ds[gtid.x];
             GroupMemoryBarrierWithGroupSync();
             
             //scatter keys into shared memory
             for (uint i = 0; i < DS_KEYS_PER_THREAD; ++i)
-                g_dsMem[offsets[i]] = keys[i];
+                g_ds[offsets[i]] = keys[i];
         
-            if (gtid.x < RADIX)
-                g_dsMem[gtid.x + PARTITION_SIZE] = b_globalHist[gtid.x + (e_radixShift << 5)] + b_passHist[gtid.x * e_threadBlocks + gid.x] - exclusiveWaveReduction;
+            g_ds[gtid.x + PART_SIZE] = b_globalHist[gtid.x + (e_radixShift << 5)] +
+                    b_passHist[gtid.x * e_threadBlocks + gid.x] - exclusiveWaveReduction;
             GroupMemoryBarrierWithGroupSync();
-        
-            //scatter runs of keys into device memory, 
-            //store the scatter location in the key register to reuse for the payload
+            
             [unroll]
-            for (uint i = 0, t = WaveGetLaneIndex() + DS_WGE16_PART_START; i < DS_KEYS_PER_THREAD; ++i, t += WaveGetLaneCount())
+            for (uint i = 0, t = SharedOffsetWGE16(gtid.x);
+                 i < DS_KEYS_PER_THREAD;
+                 ++i, t += WaveGetLaneCount())
             {
-                keys[i] = g_dsMem[(g_dsMem[t] >> e_radixShift & RADIX_MASK) + PARTITION_SIZE] + t;
-                b_alt[keys[i]] = g_dsMem[t];
+                keys[i] = g_ds[ExtractDigit(g_ds[t]) + PART_SIZE] + t;
+                b_alt[keys[i]] = g_ds[t];
             }
             GroupMemoryBarrierWithGroupSync();
-        
-            //Scatter payloads directly into shared memory
+                
             [unroll]
-            for (uint i = 0, t = WaveGetLaneIndex() + DS_WGE16_PART_START + PARTITION_START; i < DS_KEYS_PER_THREAD; ++i, t += WaveGetLaneCount())
-                g_dsMem[offsets[i]] = b_sortPayload[t];
+            for (uint i = 0, t = DeviceOffsetWGE16(gtid.x, gid.x);
+                 i < DS_KEYS_PER_THREAD; 
+                 ++i, t += WaveGetLaneCount())
+            {
+                g_ds[offsets[i]] = b_sortPayload[t];
+            }
             GroupMemoryBarrierWithGroupSync();
-        
-            //Scatter runs of payloads into device memory
+            
             [unroll]
-            for (uint i = 0, t = WaveGetLaneIndex() + DS_WGE16_PART_START; i < DS_KEYS_PER_THREAD; ++i, t += WaveGetLaneCount())
-                b_altPayload[keys[i]] = g_dsMem[t];
+            for (uint i = 0, t = SharedOffsetWGE16(gtid.x);
+                 i < DS_KEYS_PER_THREAD;
+                 ++i, t += WaveGetLaneCount())
+            {
+                b_altPayload[keys[i]] = g_ds[t];
+            }
         }
         
         if (WaveGetLaneCount() < 16)
         {
-            const uint serialIterations = (DS_THREADS / WaveGetLaneCount() + 31) / 32;
+            const uint serialIterations = (DS_DIM / WaveGetLaneCount() + 31) / 32;
             
             //Load keys into registers
             [unroll]
-            for (uint i = 0, t = WaveGetLaneIndex() + DS_WLT16_PART_START + PARTITION_START; i < DS_KEYS_PER_THREAD; ++i, t += WaveGetLaneCount() * serialIterations)
+            for (uint i = 0, t = DeviceOffsetWLT16(gtid.x, gid.x, serialIterations);
+                 i < DS_KEYS_PER_THREAD;
+                 ++i, t += WaveGetLaneCount() * serialIterations)
+            {
                 keys[i] = b_sort[t];
-            
-            //clear shared memory, max histogram size is divided by two because we are bitpacking
-            for (uint i = gtid.x; i < DS_WLT16_HISTS_SIZE; i += DS_THREADS)
-                g_dsMem[i] = 0;
+            }
+                
+            //clear shared memory
+            for (uint i = gtid.x; i < WaveHistsSizeWLT16(); i += DS_DIM)
+                g_ds[i] = 0;
             GroupMemoryBarrierWithGroupSync();
             
+            const uint ltMask = (1U << WaveGetLaneIndex()) - 1;
+            [unroll]
+            for (uint i = 0; i < DS_KEYS_PER_THREAD; ++i)
             {
-                uint waveFlag;
-                uint leMask = (1U << (WaveGetLaneIndex() + 1)) - 1; //for full agnostic add ternary
-            
+                uint waveFlag = (1U << WaveGetLaneCount()) - 1; //for full agnostic add ternary and uint4
+                
                 [unroll]
-                for (uint i = 0; i < DS_KEYS_PER_THREAD; ++i)
+                for (uint k = 0; k < RADIX_LOG; ++k)
                 {
-                    waveFlag = (1U << WaveGetLaneCount()) - 1; //for full agnostic add ternary and uint4
+                    const bool t = keys[i] >> (k + e_radixShift) & 1;
+                    waveFlag &= (t ? 0 : 0xffffffff) ^ (uint) WaveActiveBallot(t);
+                }
                 
-                    for (uint k = e_radixShift; k < e_radixShift + RADIX_LOG; ++k)
-                    {
-                        const bool t = keys[i] >> k & 1;
-                        waveFlag &= (t ? 0 : 0xffffffff) ^ (uint) WaveActiveBallot(t);
-                    }
-                
-                    uint bits = countbits(waveFlag & leMask);
-                    const uint index = (keys[i] >> (e_radixShift + 1) & HALF_MASK) + (WAVE_INDEX / serialIterations * HALF_RADIX);
+                uint bits = countbits(waveFlag & ltMask);
+                const uint index = ExtractPackedIndex(keys[i]) +
+                    (getWaveIndex(gtid.x) / serialIterations * HALF_RADIX);
                     
-                    for (uint k = 0; k < serialIterations; ++k)
-                    {
-                        if ((WAVE_INDEX % serialIterations) == k)
-                            offsets[i] = (g_dsMem[index] >> ((keys[i] >> e_radixShift & 1) ? 16 : 0) & 0xffff) + bits - 1;
+                for (uint k = 0; k < serialIterations; ++k)
+                {
+                    if (getWaveIndex(gtid.x) % serialIterations == k)
+                        offsets[i] = ExtractPackedValue(g_ds[index], keys[i]) + bits;
                     
-                        GroupMemoryBarrierWithGroupSync();
-                        if ((WAVE_INDEX % serialIterations) == k && bits == 1)
-                            InterlockedAdd(g_dsMem[index], countbits(waveFlag) << ((keys[i] >> e_radixShift & 1) ? 16 : 0));
-                        GroupMemoryBarrierWithGroupSync();
+                    GroupMemoryBarrierWithGroupSync();
+                    if (getWaveIndex(gtid.x) % serialIterations == k && bits == 0)
+                    {
+                        InterlockedAdd(g_ds[index],
+                            countbits(waveFlag) << ExtractPackedShift(keys[i]));
                     }
+                    GroupMemoryBarrierWithGroupSync();
                 }
             }
             
             //inclusive/exclusive prefix sum up the histograms,
             //use a blelloch scan for in place exclusive
+            uint reduction;
+            if (gtid.x < HALF_RADIX)
             {
-                uint reduction;
-                if (gtid.x < HALF_RADIX)
+                reduction = g_ds[gtid.x];
+                for (uint i = gtid.x + HALF_RADIX; i < WaveHistsSizeWLT16(); i += HALF_RADIX)
                 {
-                    reduction = g_dsMem[gtid.x];
-                    for (uint i = gtid.x + HALF_RADIX; i < DS_WLT16_HISTS_SIZE; i += HALF_RADIX)
-                    {
-                        reduction += g_dsMem[i];
-                        g_dsMem[i] = reduction - g_dsMem[i];
-                    }
-                    g_dsMem[gtid.x] = reduction + (reduction << 16);
+                    reduction += g_ds[i];
+                    g_ds[i] = reduction - g_ds[i];
                 }
-                
-                uint shift = 1;
-                for (uint j = RADIX >> 2; j > 0; j >>= 1)
-                {
-                    GroupMemoryBarrierWithGroupSync();
-                    for (int i = gtid.x; i < j; i += UPSWEEP_THREADS)
-                        g_dsMem[((((i << 1) + 2) << shift) - 1) >> 1] += g_dsMem[((((i << 1) + 1) << shift) - 1) >> 1] & 0xffff0000;
-                    shift++;
-                }
-                GroupMemoryBarrierWithGroupSync();
-                
-                if (gtid.x == 0)
-                    g_dsMem[HALF_RADIX - 1] &= 0xffff;
-                
-                for (uint j = 1; j < RADIX >> 1; j <<= 1)
-                {
-                    --shift;
-                    GroupMemoryBarrierWithGroupSync();
-                    for (uint i = gtid.x; i < j; i += UPSWEEP_THREADS)
-                    {
-                        const uint t = ((((i << 1) + 1) << shift) - 1) >> 1;
-                        const uint t2 = ((((i << 1) + 2) << shift) - 1) >> 1;
-                        const uint t3 = g_dsMem[t];
-                        g_dsMem[t] = (g_dsMem[t] & 0xffff) | (g_dsMem[t2] & 0xffff0000);
-                        g_dsMem[t2] += t3 & 0xffff0000;
-                    }
-                }
-
-                GroupMemoryBarrierWithGroupSync();
-                if (gtid.x < HALF_RADIX)
-                {
-                    const uint t = g_dsMem[gtid.x];
-                    g_dsMem[gtid.x] = (t >> 16) + (t << 16) + (t & 0xffff0000);
-                }
-                GroupMemoryBarrierWithGroupSync();
+                g_ds[gtid.x] = reduction + (reduction << 16);
             }
+                
+            uint shift = 1;
+            for (uint j = RADIX >> 2; j > 0; j >>= 1)
+            {
+                GroupMemoryBarrierWithGroupSync();
+                for (int i = gtid.x; i < j; i += DS_DIM)
+                {
+                    g_ds[((((i << 1) + 2) << shift) - 1) >> 1] +=
+                            g_ds[((((i << 1) + 1) << shift) - 1) >> 1] & 0xffff0000;
+                }
+                shift++;
+            }
+            GroupMemoryBarrierWithGroupSync();
+                
+            if (gtid.x == 0)
+                g_ds[HALF_RADIX - 1] &= 0xffff;
+                
+            for (uint j = 1; j < RADIX >> 1; j <<= 1)
+            {
+                --shift;
+                GroupMemoryBarrierWithGroupSync();
+                for (uint i = gtid.x; i < j; i += DS_DIM)
+                {
+                    const uint t = ((((i << 1) + 1) << shift) - 1) >> 1;
+                    const uint t2 = ((((i << 1) + 2) << shift) - 1) >> 1;
+                    const uint t3 = g_ds[t];
+                    g_ds[t] = (g_ds[t] & 0xffff) | (g_ds[t2] & 0xffff0000);
+                    g_ds[t2] += t3 & 0xffff0000;
+                }
+            }
+
+            GroupMemoryBarrierWithGroupSync();
+            if (gtid.x < HALF_RADIX)
+            {
+                const uint t = g_ds[gtid.x];
+                g_ds[gtid.x] = (t >> 16) + (t << 16) + (t & 0xffff0000);
+            }
+            GroupMemoryBarrierWithGroupSync();
             
             //Update offsets
             if (gtid.x >= WaveGetLaneCount() * serialIterations)
             {
-                const uint t = WAVE_INDEX / serialIterations * HALF_RADIX;
+                const uint t = getWaveIndex(gtid.x) / serialIterations * HALF_RADIX;
                 [unroll]
                 for (uint i = 0; i < DS_KEYS_PER_THREAD; ++i)
                 {
-                    const uint t2 = keys[i] >> (e_radixShift + 1) & HALF_MASK;
-                    offsets[i] += (g_dsMem[t2 + t] + g_dsMem[t2]) >> ((keys[i] >> e_radixShift & 1) ? 16 : 0) & 0xffff;
+                    const uint t2 = ExtractPackedIndex(keys[i]);
+                    offsets[i] += ExtractPackedValue(g_ds[t2 + t] + g_ds[t2], keys[i]);
                 }
             }
             else
             {
                 [unroll]
                 for (uint i = 0; i < DS_KEYS_PER_THREAD; ++i)
-                    offsets[i] += g_dsMem[keys[i] >> (e_radixShift + 1) & HALF_MASK] >> ((keys[i] >> e_radixShift & 1) ? 16 : 0) & 0xffff;
+                    offsets[i] += ExtractPackedValue(g_ds[ExtractPackedIndex(keys[i])], keys[i]);
             }
             
-            if (gtid.x < RADIX)
-                exclusiveWaveReduction = g_dsMem[gtid.x >> 1] >> ((gtid.x & 1) ? 16 : 0) & 0xffff;
+            const uint exclusiveWaveReduction = g_ds[gtid.x >> 1] >> ((gtid.x & 1) ? 16 : 0) & 0xffff;
             GroupMemoryBarrierWithGroupSync();
             
             //scatter keys into shared memory
             for (uint i = 0; i < DS_KEYS_PER_THREAD; ++i)
-                g_dsMem[offsets[i]] = keys[i];
+                g_ds[offsets[i]] = keys[i];
         
-            if (gtid.x < RADIX)
-                g_dsMem[gtid.x + PARTITION_SIZE] = b_globalHist[gtid.x + (e_radixShift << 5)] + b_passHist[gtid.x * e_threadBlocks + gid.x] - exclusiveWaveReduction;
+            g_ds[gtid.x + PART_SIZE] = b_globalHist[gtid.x + (e_radixShift << 5)] +
+                    b_passHist[gtid.x * e_threadBlocks + gid.x] - exclusiveWaveReduction;
             GroupMemoryBarrierWithGroupSync();
         
             //scatter runs of keys into device memory, 
             //store the scatter location in the key register to reuse for the payload
             [unroll]
-            for (uint i = 0, t = WaveGetLaneIndex() + DS_WLT16_PART_START; i < DS_KEYS_PER_THREAD; ++i, t += WaveGetLaneCount() * serialIterations)
+            for (uint i = 0, t = SharedOffsetWLT16(gtid.x, serialIterations);
+                 i < DS_KEYS_PER_THREAD;
+                 ++i, t += WaveGetLaneCount() * serialIterations)
             {
-                keys[i] = g_dsMem[(g_dsMem[t] >> e_radixShift & RADIX_MASK) + PARTITION_SIZE] + t;
-                b_alt[keys[i]] = g_dsMem[t];
+                keys[i] = g_ds[ExtractDigit(g_ds[t]) + PART_SIZE] + t;
+                b_alt[keys[i]] = g_ds[t];
             }
             GroupMemoryBarrierWithGroupSync();
-        
-            //Scatter payloads directly into shared memory
+                
             [unroll]
-            for (uint i = 0, t = WaveGetLaneIndex() + DS_WLT16_PART_START + PARTITION_START; i < DS_KEYS_PER_THREAD; ++i, t += WaveGetLaneCount() * serialIterations)
-                g_dsMem[offsets[i]] = b_sortPayload[t];
+            for (uint i = 0, t = DeviceOffsetWLT16(gtid.x, gid.x, serialIterations);
+                 i < DS_KEYS_PER_THREAD; 
+                 ++i, t += WaveGetLaneCount() * serialIterations)
+            {
+                g_ds[offsets[i]] = b_sortPayload[t];
+            }
             GroupMemoryBarrierWithGroupSync();
-        
-            //Scatter runs of payloads into device memory
+            
             [unroll]
-            for (uint i = 0, t = WaveGetLaneIndex() + DS_WLT16_PART_START; i < DS_KEYS_PER_THREAD; ++i, t += WaveGetLaneCount() * serialIterations)
-                b_altPayload[keys[i]] = g_dsMem[t];
+            for (uint i = 0, t = SharedOffsetWLT16(gtid.x, serialIterations);
+                 i < DS_KEYS_PER_THREAD;
+                 ++i, t += WaveGetLaneCount() * serialIterations)
+            {
+                b_altPayload[keys[i]] = g_ds[t];
+            }
         }
     }
     
@@ -635,51 +731,57 @@ void Downsweep(uint3 gtid : SV_GroupThreadID, uint3 gid : SV_GroupID)
     {
         //load the global and pass histogram values into shared memory
         if (gtid.x < RADIX)
-            g_dsMem[gtid.x] = b_globalHist[gtid.x + (e_radixShift << 5)] + b_passHist[gtid.x * e_threadBlocks + gid.x];
+        {
+            g_ds[gtid.x] = b_globalHist[gtid.x + (e_radixShift << 5)] +
+                b_passHist[gtid.x * e_threadBlocks + gid.x];
+        }
         GroupMemoryBarrierWithGroupSync();
         
         const uint waveParts = (WaveGetLaneCount() + 31) / 32;
-        for (int i = gtid.x + PARTITION_START; i < PARTITION_START + PARTITION_SIZE; i += DS_THREADS)
+        for (int i = gtid.x + gid.x * PART_SIZE; i < (gid.x + 1) * PART_SIZE; i += DS_DIM)
         {
             uint key;
             if (i < e_numKeys)
+            {
                 key = b_sort[i];
+            }
             
-            uint4 waveFlags = (WaveGetLaneCount() & 31) ? (1U << WaveGetLaneCount()) - 1 : 0xffffffff;
+            uint4 waveFlags = (WaveGetLaneCount() & 31) ?
+                (1U << WaveGetLaneCount()) - 1 : 0xffffffff;
             uint offset;
             uint bits = 0;
-            
             if (i < e_numKeys)
             {
-                for (int k = e_radixShift; k < e_radixShift + RADIX_LOG; ++k)
+                [unroll]
+                for (uint k = 0; k < RADIX_LOG; ++k)
                 {
-                    const bool t = key >> k & 1;
+                    const bool t = key >> (k + e_radixShift) & 1;
                     const uint4 ballot = WaveActiveBallot(t);
                     for (int wavePart = 0; wavePart < waveParts; ++wavePart)
                         waveFlags[wavePart] &= (t ? 0 : 0xffffffff) ^ ballot[wavePart];
                 }
             
-                for (int wavePart = 0; wavePart < waveParts; ++wavePart)
+                for (uint wavePart = 0; wavePart < waveParts; ++wavePart)
                 {
                     if (WaveGetLaneIndex() >= wavePart * 32)
                     {
-                        const uint leMask = WaveGetLaneIndex() >= ((wavePart + 1) * 32) - 1 ? 0xffffffff :
-                            (1U << ((WaveGetLaneIndex() & 31) + 1)) - 1;
-                        bits += countbits(waveFlags[wavePart] & leMask);
+                        const uint ltMask = WaveGetLaneIndex() >= (wavePart + 1) * 32 ?
+                            0xffffffff : (1U << (WaveGetLaneIndex() & 31)) - 1;
+                        bits += countbits(waveFlags[wavePart] & ltMask);
                     }
                 }
             }
             
-            for (int k = 0; k < DS_THREADS / WaveGetLaneCount(); ++k)
+            for (int k = 0; k < DS_DIM / WaveGetLaneCount(); ++k)
             {
-                if (WAVE_INDEX == k && i < e_numKeys)
-                    offset = g_dsMem[key >> e_radixShift & RADIX_MASK] + bits - 1;
+                if (getWaveIndex(gtid.x) == k && i < e_numKeys)
+                    offset = g_ds[key >> e_radixShift & RADIX_MASK] + bits;
                 GroupMemoryBarrierWithGroupSync();
                 
-                if (WAVE_INDEX == k && i < e_numKeys && bits == 1)
+                if (getWaveIndex(gtid.x) == k && i < e_numKeys && bits == 0)
                 {
                     for (int wavePart = 0; wavePart < waveParts; ++wavePart)
-                        g_dsMem[key >> e_radixShift & RADIX_MASK] += countbits(waveFlags[wavePart]);
+                        g_ds[key >> e_radixShift & RADIX_MASK] += countbits(waveFlags[wavePart]);
                 }
                 GroupMemoryBarrierWithGroupSync();
             }

--- a/package/Shaders/DeviceRadixSort.hlsl
+++ b/package/Shaders/DeviceRadixSort.hlsl
@@ -1,0 +1,335 @@
+/******************************************************************************
+ * Device Level 8-bit LSD Radix Sort using reduce then scan
+ *
+ * SPDX-License-Identifier: MIT
+ * Copyright Thomas Smith 12/6/2023
+ *  
+ *  Permission is hereby granted, free of charge, to any person obtaining a copy
+ *  of this software and associated documentation files (the "Software"), to deal
+ *  in the Software without restriction, including without limitation the rights
+ *  to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
+ *  copies of the Software, and to permit persons to whom the Software is
+ *  furnished to do so, subject to the following conditions:
+ *
+ *  The above copyright notice and this permission notice shall be included in all
+ *  copies or substantial portions of the Software.
+ *
+ *  THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+ *  IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+ *  FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+ *  AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+ *  LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+ *  OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE
+ *  SOFTWARE.
+ ******************************************************************************/
+
+//General macros 
+#define PARTITION_SIZE      7680    //size of a partition tile
+
+#define RADIX               256     //Number of digit bins
+#define RADIX_MASK          255     //Mask of digit bins
+#define RADIX_LOG           8       //log2(RADIX)
+
+#define WAVE_INDEX          (gtid.x / WaveGetLaneCount())
+#define PARTITION_START     (gid.x * PARTITION_SIZE)
+
+#define UPSWEEP_THREADS     64      //The number of threads in a Upsweep threadblock
+#define SCAN_THREADS        64      //The number of threads in a Scan threadblock
+#define DS_THREADS          512     //The number of threads in a Downsweep threadblock
+
+//For the downsweep kernels
+#define DS_HISTS_SIZE       4096    //The total size of all wave histograms in shared memory
+#define DS_WAVE_PART_SIZE   480     //The subpartition size of a single wave in a BinningPass threadblock
+#define DS_KEYS_PER_THREAD  15      //The number of keys per thread in BinningPass threadblock
+#define DS_WAVE_PART_START  (WAVE_INDEX * DS_WAVE_PART_SIZE)     //The starting offset of a subpartition tile
+
+//needs to match original cBuffer size?
+cbuffer cbParallelSort : register(b0)
+{
+    uint e_numKeys;
+    uint e_radixShift;
+    uint e_threadBlocks;
+    uint padding0;
+    uint padding1;
+    uint padding2;
+    uint padding3;
+    uint padding4;
+};
+
+RWStructuredBuffer<uint> b_polling;     //buffer used to grab the wave size during intialization
+RWStructuredBuffer<uint> b_sort;        //buffer to be sorted
+RWStructuredBuffer<uint> b_sortPayload; //payload buffer
+RWStructuredBuffer<uint> b_alt;         //double buffer
+RWStructuredBuffer<uint> b_altPayload;  //double buffer payload
+RWStructuredBuffer<uint> b_globalHist;  //buffer holding device level offsets for each binning pass
+RWStructuredBuffer<uint> b_passHist;    //buffer used to store reduced sums of partition tiles
+
+groupshared uint g_upsweepHist[RADIX];  //Shared memory for upsweep
+groupshared uint g_scan[SCAN_THREADS];  //Shared memory for scan
+
+groupshared uint g_localHist[RADIX];    //Threadgroup copy of globalHist during downsweep
+groupshared uint g_waveHists[PARTITION_SIZE];   //Shared memory for the per wave histograms during downsweep
+
+//Clear the global histogram, as we will be adding to it atomically
+[numthreads(1024, 1, 1)]
+void InitDeviceRadixSort(int3 id : SV_DispatchThreadID)
+{
+    b_globalHist[id.x] = 0;
+}
+
+//Ask the GPU how many lanes are in a wave
+[numthreads(1, 1, 1)]
+void PollWaveSize(int3 gtid : SV_GroupThreadID)
+{
+    b_polling[0] = WaveGetLaneCount();
+}
+
+[numthreads(UPSWEEP_THREADS, 1, 1)]
+void Upsweep(int3 gtid : SV_GroupThreadID, int3 gid : SV_GroupID)
+{
+    //clear shared memory
+    for (int i = gtid.x; i < RADIX; i += UPSWEEP_THREADS)
+        g_upsweepHist[i] = 0;
+    GroupMemoryBarrierWithGroupSync();
+
+    //histogram
+    {
+        const int radixShift = e_radixShift;
+        const int partitionEnd = gid.x == e_threadBlocks - 1 ? e_numKeys : (gid.x + 1) * PARTITION_SIZE;
+        for (int i = gtid.x + PARTITION_START; i < partitionEnd; i += UPSWEEP_THREADS)
+            InterlockedAdd(g_upsweepHist[b_sort[i] >> radixShift & RADIX_MASK], 1);
+    }
+    GroupMemoryBarrierWithGroupSync();
+    
+    //pass tile to pass histogram
+    {
+        const int threadBlocks = e_threadBlocks;
+        for (int i = gtid.x; i < RADIX; i += UPSWEEP_THREADS)
+            b_passHist[i * threadBlocks + gid.x] = g_upsweepHist[i];
+    }
+    GroupMemoryBarrierWithGroupSync();
+    
+    //exclusive prefix sum over the counts
+    {
+        const int laneMask = WaveGetLaneCount() - 1;
+        const int circularLaneShift = WaveGetLaneIndex() + 1 & laneMask;
+        for (int i = gtid.x; i < RADIX; i += UPSWEEP_THREADS)
+            g_upsweepHist[circularLaneShift + (i & ~laneMask)] = g_upsweepHist[i] + WavePrefixSum(g_upsweepHist[i]);
+    }
+    GroupMemoryBarrierWithGroupSync();
+    
+    if (WaveGetLaneIndex() < (RADIX / WaveGetLaneCount()) && WAVE_INDEX == 0)
+        g_upsweepHist[WaveGetLaneIndex() * WaveGetLaneCount()] = WavePrefixSum(g_upsweepHist[WaveGetLaneIndex() * WaveGetLaneCount()]);
+    GroupMemoryBarrierWithGroupSync();
+    
+    //atomically add to global histogram
+    {
+        const int offset = e_radixShift << 5;
+        for (int i = gtid.x; i < RADIX; i += UPSWEEP_THREADS)
+            InterlockedAdd(b_globalHist[i + offset], (WaveGetLaneIndex() ? g_upsweepHist[i] : 0) + WaveReadLaneAt(g_upsweepHist[i], 0));
+    }
+}
+
+//Scan along the spine of the upsweep
+[numthreads(SCAN_THREADS, 1, 1)]
+void Scan(int3 gtid : SV_GroupThreadID, int3 gid : SV_GroupID)
+{
+    unsigned int aggregate = 0;
+    const int threadBlocks = e_threadBlocks;
+    const int circularLaneShift = WaveGetLaneIndex() + 1 & WaveGetLaneCount() - 1;
+    const int offset = (gid.x * (SCAN_THREADS / WaveGetLaneCount()) + WAVE_INDEX) * threadBlocks;
+    const int waveOffset = WAVE_INDEX * WaveGetLaneCount();
+    
+    for (int i = WaveGetLaneIndex(); i < threadBlocks; i += WaveGetLaneCount())
+    {
+        g_scan[WaveGetLaneIndex() + waveOffset] = b_passHist[i + offset];
+        g_scan[circularLaneShift + waveOffset] = g_scan[WaveGetLaneIndex() + waveOffset] +
+            WavePrefixSum(g_scan[WaveGetLaneIndex() + waveOffset]);
+        b_passHist[i + offset] = (WaveGetLaneIndex() ? g_scan[WaveGetLaneIndex() + waveOffset] : 0) + aggregate;
+        aggregate += WaveReadLaneAt(g_scan[WaveGetLaneIndex() + waveOffset], 0);
+    }
+}
+
+[numthreads(DS_THREADS, 1, 1)]
+void Downsweep(int3 gtid : SV_GroupThreadID, int3 gid : SV_GroupID)
+{
+    //load the global and pass histogram values into shared memory
+    if (gtid.x < RADIX)
+        g_localHist[gtid.x] = b_globalHist[gtid.x + (e_radixShift << 5)] + b_passHist[gtid.x * e_threadBlocks + gid.x];
+    
+    //Each wave clears its own portion of shared memory
+    {
+        const int waveHistEnd = (WAVE_INDEX + 1) * RADIX;
+        for (int i = WaveGetLaneIndex() + WAVE_INDEX * RADIX; i < waveHistEnd; i += WaveGetLaneCount())
+            g_waveHists[i] = 0;
+    }
+    
+    if (gid.x != e_threadBlocks - 1)
+    {
+        //Load keys into registers
+        uint keys[DS_KEYS_PER_THREAD];
+        [unroll]
+        for (int i = 0, t = WaveGetLaneIndex() + DS_WAVE_PART_START + PARTITION_START; i < DS_KEYS_PER_THREAD; ++i, t += WaveGetLaneCount())
+            keys[i] = b_sort[t];
+
+        //Warp Level Multisplit, should support SIMD width up to 128
+        uint offsets[DS_KEYS_PER_THREAD];
+        {
+            const uint waveParts = WaveGetLaneCount() / 32;
+            uint4 waveFlags;
+            
+            [unroll]
+            for (int i = 0; i < DS_KEYS_PER_THREAD; ++i)
+            {
+                waveFlags = 0xffffffff;
+
+                for (int k = e_radixShift; k < e_radixShift + RADIX_LOG; ++k)
+                {
+                    const bool t = keys[i] >> k & 1;
+                    const uint4 ballot = WaveActiveBallot(t);
+                    for (int wavePart = 0; wavePart < waveParts; ++wavePart)
+                        waveFlags[wavePart] &= (t ? 0 : 0xffffffff) ^ ballot[wavePart];
+                }
+                
+                uint bits = 0;
+                for (int wavePart = 0; wavePart < waveParts; ++wavePart)
+                {
+                    const uint shift = WaveGetLaneIndex() >= (wavePart + 1) * 32 ? 0 : WaveGetLaneCount() - WaveGetLaneIndex() - 1;
+                    bits += countbits(waveFlags[wavePart] << shift);
+                }
+                    
+                const int index = (keys[i] >> e_radixShift & RADIX_MASK) + (WAVE_INDEX * RADIX);
+                offsets[i] = g_waveHists[index] + bits - 1;
+                if (bits == 1)
+                {
+                    for (int wavePart = 0; wavePart < waveParts; ++wavePart)
+                        g_waveHists[index] += countbits(waveFlags[wavePart]);
+                }
+            }
+        }
+        GroupMemoryBarrierWithGroupSync();
+        
+        //exclusive prefix sum across the histograms
+        if (gtid.x < RADIX)
+        {
+            for (int k = gtid.x + RADIX; k < DS_HISTS_SIZE; k += RADIX)
+            {
+                g_waveHists[gtid.x] += g_waveHists[k];
+                g_waveHists[k] = g_waveHists[gtid.x] - g_waveHists[k];
+            }
+        }
+        GroupMemoryBarrierWithGroupSync();
+
+        //exclusive prefix sum across the reductions
+        {
+            const uint t = (WaveGetLaneIndex() + 1 & WaveGetLaneCount() - 1) + (WAVE_INDEX * WaveGetLaneCount());
+            if (gtid.x < RADIX)
+                g_waveHists[t] = WavePrefixSum(g_waveHists[gtid.x]) + g_waveHists[gtid.x];
+            GroupMemoryBarrierWithGroupSync();
+        
+            if (WaveGetLaneIndex() < (RADIX / WaveGetLaneCount()) && WAVE_INDEX == 0)
+                g_waveHists[WaveGetLaneIndex() * WaveGetLaneCount()] =
+                WavePrefixSum(g_waveHists[WaveGetLaneIndex() * WaveGetLaneCount()]);
+            GroupMemoryBarrierWithGroupSync();
+
+            if (gtid.x < RADIX)
+            {
+                if (WaveGetLaneIndex())
+                    g_waveHists[gtid.x] += WaveReadLaneAt(g_waveHists[gtid.x - 1], 1);
+                g_localHist[gtid.x] -= g_waveHists[gtid.x];
+            }
+        }
+        
+        GroupMemoryBarrierWithGroupSync();
+        
+        //Update offsets
+        if (gtid.x >= WaveGetLaneCount())
+        {
+            const uint t = WAVE_INDEX * RADIX;
+            [unroll]
+            for (int i = 0; i < DS_KEYS_PER_THREAD; ++i)
+            {
+                const uint t2 = keys[i] >> e_radixShift & RADIX_MASK;
+                offsets[i] += g_waveHists[t2 + t] + g_waveHists[t2];
+            }
+        }
+        else
+        {
+            [unroll]
+            for (int i = 0; i < DS_KEYS_PER_THREAD; ++i)
+                offsets[i] += g_waveHists[keys[i] >> e_radixShift & RADIX_MASK];
+        }
+        GroupMemoryBarrierWithGroupSync();
+        
+        //scatter keys into shared memory
+        for (int i = 0; i < DS_KEYS_PER_THREAD; ++i)
+            g_waveHists[offsets[i]] = keys[i];
+        GroupMemoryBarrierWithGroupSync();
+        
+        //scatter runs of keys into device memory, 
+        //store the scatter location in the key register to reuse for the payload
+        [unroll]
+        for (int i = 0, t = WaveGetLaneIndex() + DS_WAVE_PART_START; i < DS_KEYS_PER_THREAD; ++i, t += WaveGetLaneCount())
+        {
+            keys[i] = g_localHist[g_waveHists[t] >> e_radixShift & RADIX_MASK] + t;
+            b_alt[keys[i]] = g_waveHists[t];
+        }
+        GroupMemoryBarrierWithGroupSync();
+        
+        //Scatter payloads directly into shared memory
+        [unroll]
+        for (int i = 0, t = WaveGetLaneIndex() + DS_WAVE_PART_START + PARTITION_START; i < DS_KEYS_PER_THREAD; ++i, t += WaveGetLaneCount())
+            g_waveHists[offsets[i]] = b_sortPayload[t];
+        GroupMemoryBarrierWithGroupSync();
+        
+        //Scatter runs of payloads into device memory
+        [unroll]
+        for (int i = 0, t = WaveGetLaneIndex() + DS_WAVE_PART_START; i < DS_KEYS_PER_THREAD; ++i, t += WaveGetLaneCount())
+            b_altPayload[keys[i]] = g_waveHists[t];
+    }
+    else
+    {
+        GroupMemoryBarrierWithGroupSync();
+        
+        //perform the sort on the final partition slightly differently 
+        //to handle input sizes not perfect multiples of the partition
+        const uint waveParts = WaveGetLaneCount() / 32;
+        for (int i = gtid.x + PARTITION_START; i < e_numKeys; i += DS_THREADS)
+        {
+            const uint key = b_sort[i];
+            uint4 waveFlags = 0xffffffff;
+            for (int k = e_radixShift; k < e_radixShift + RADIX_LOG; ++k)
+            {
+                const bool t = key >> k & 1;
+                const uint4 ballot = WaveActiveBallot(t);
+                for (int wavePart = 0; wavePart < waveParts; ++wavePart)
+                    waveFlags[wavePart] &= (t ? 0 : 0xffffffff) ^ ballot[wavePart];
+            }
+            
+            uint offset;
+            uint bits = 0;
+            for (int wavePart = 0; wavePart < waveParts; ++wavePart)
+            {
+                const uint shift = WaveGetLaneIndex() >= (wavePart + 1) * 32 ? 0 : WaveGetLaneCount() - WaveGetLaneIndex() - 1;
+                bits += countbits(waveFlags[wavePart] << shift);
+            }
+            
+            for (int k = 0; k < DS_THREADS / WaveGetLaneCount(); ++k)
+            {
+                if (WAVE_INDEX == k)
+                {
+                    offset = g_localHist[key >> e_radixShift & RADIX_MASK] + bits - 1;
+                    if (bits == 1)
+                    {
+                        for (int wavePart = 0; wavePart < waveParts; ++wavePart)
+                            g_localHist[key >> e_radixShift & RADIX_MASK] += countbits(waveFlags[wavePart]);
+                    }
+                }
+                GroupMemoryBarrierWithGroupSync();
+            }
+
+            b_alt[offset] = key;
+            b_altPayload[offset] = b_sortPayload[i];
+        }
+    }
+}

--- a/package/Shaders/DeviceRadixSort.hlsl
+++ b/package/Shaders/DeviceRadixSort.hlsl
@@ -24,26 +24,30 @@
  ******************************************************************************/
 
 //General macros 
-#define PARTITION_SIZE      7680    //size of a partition tile
+#define PARTITION_SIZE      7680U   //size of a partition tile
+#define MAX_DS_SMEM         8192U
 
-#define RADIX               256     //Number of digit bins
-#define RADIX_MASK          255     //Mask of digit bins
-#define RADIX_LOG           8       //log2(RADIX)
+#define RADIX               256U    //Number of digit bins
+#define RADIX_MASK          255U    //Mask of digit bins
+#define RADIX_LOG           8U      //log2(RADIX)
+
+//For smaller waves where bit packing is necessary
+#define HALF_RADIX          128U    
+#define HALF_MASK           127U
 
 #define WAVE_INDEX          (gtid.x / WaveGetLaneCount())
 #define PARTITION_START     (gid.x * PARTITION_SIZE)
 
-#define UPSWEEP_THREADS     64      //The number of threads in a Upsweep threadblock
-#define SCAN_THREADS        64      //The number of threads in a Scan threadblock
-#define DS_THREADS          512     //The number of threads in a Downsweep threadblock
+#define UPSWEEP_THREADS     128U    //The number of threads in a Upsweep threadblock
+#define SCAN_THREADS        128U    //The number of threads in a Scan threadblock
+#define DS_THREADS          512U    //The number of threads in a Downsweep threadblock
 
 //For the downsweep kernels
-#define DS_KEYS_PER_THREAD  15                                          //The number of keys per thread in BinningPass threadblock
-#define DS_WAVE_PART_SIZE   480                                         //The subpartition size of a single wave in a BinningPass threadblock
+#define DS_KEYS_PER_THREAD  15U                                         //The number of keys per thread in BinningPass threadblock
+#define DS_WAVE_PART_SIZE   480U                                        //The subpartition size of a single wave in a BinningPass threadblock
 #define DS_WAVE_PART_START  (WAVE_INDEX * DS_WAVE_PART_SIZE)            //The starting offset of a subpartition tile
-#define DS_HISTS_SIZE       (DS_THREADS / WaveGetLaneCount() * RADIX)   //The total size of all wave histograms in shared memory
+#define DS_HISTS_SIZE       (DS_THREADS / WaveGetLaneCount() * RADIX)   //The total size of all wave histograms in shared memory //TODO rename this
 
-//needs to match original cBuffer size?
 cbuffer cbParallelSort : register(b0)
 {
     uint e_numKeys;
@@ -56,17 +60,16 @@ cbuffer cbParallelSort : register(b0)
     uint padding4;
 };
 
-RWStructuredBuffer<uint> b_polling;     //buffer used to grab the wave size during intialization
-RWStructuredBuffer<uint> b_sort;        //buffer to be sorted
-RWStructuredBuffer<uint> b_sortPayload; //payload buffer
-RWStructuredBuffer<uint> b_alt;         //double buffer
-RWStructuredBuffer<uint> b_altPayload;  //double buffer payload
-RWStructuredBuffer<uint> b_globalHist;  //buffer holding device level offsets for each binning pass
-RWStructuredBuffer<uint> b_passHist;    //buffer used to store reduced sums of partition tiles
+RWStructuredBuffer<uint> b_sort;            //buffer to be sorted
+RWStructuredBuffer<uint> b_sortPayload;     //payload buffer
+RWStructuredBuffer<uint> b_alt;             //double buffer
+RWStructuredBuffer<uint> b_altPayload;      //double buffer payload
+RWStructuredBuffer<uint> b_globalHist;      //buffer holding device level offsets for each binning pass
+RWStructuredBuffer<uint> b_passHist;        //buffer used to store reduced sums of partition tiles
 
-groupshared uint g_upsweepHist[RADIX];  //Shared memory for upsweep
-groupshared uint g_localHist[RADIX];    //Threadgroup copy of globalHist during downsweep
-groupshared uint g_waveHists[PARTITION_SIZE];   //Shared memory for the per wave histograms during downsweep
+groupshared uint g_upsweepHist[RADIX * 2];  //Shared memory for upsweep
+groupshared uint g_scanMem[SCAN_THREADS];   //Shared memory for the scan
+groupshared uint g_dsMem[MAX_DS_SMEM];      //Shared memory for the downsweep
 
 //Clear the global histogram, as we will be adding to it atomically
 [numthreads(1024, 1, 1)]
@@ -75,56 +78,107 @@ void InitDeviceRadixSort(int3 id : SV_DispatchThreadID)
     b_globalHist[id.x] = 0;
 }
 
-//Ask the GPU how many lanes are in a wave
-[numthreads(1, 1, 1)]
-void PollWaveSize(int3 gtid : SV_GroupThreadID)
-{
-    b_polling[0] = WaveGetLaneCount();
-}
-
 [numthreads(UPSWEEP_THREADS, 1, 1)]
-void Upsweep(int3 gtid : SV_GroupThreadID, int3 gid : SV_GroupID)
+void Upsweep(uint3 gtid : SV_GroupThreadID, uint3 gid : SV_GroupID)
 {
     //clear shared memory
-    for (int i = gtid.x; i < RADIX; i += UPSWEEP_THREADS)
-        g_upsweepHist[i] = 0;
+    {
+        const uint histsEnd = RADIX * 2;
+        for (uint i = gtid.x; i < histsEnd; i += UPSWEEP_THREADS)
+            g_upsweepHist[i] = 0;
+    }
     GroupMemoryBarrierWithGroupSync();
 
-    //histogram
+    //histogram, 64 threads to a histogram
     {
-        const int radixShift = e_radixShift;
-        const int partitionEnd = gid.x == e_threadBlocks - 1 ? e_numKeys : (gid.x + 1) * PARTITION_SIZE;
-        for (int i = gtid.x + PARTITION_START; i < partitionEnd; i += UPSWEEP_THREADS)
-            InterlockedAdd(g_upsweepHist[b_sort[i] >> radixShift & RADIX_MASK], 1);
+        const uint radixShift = e_radixShift;
+        const uint offset = gtid.x / 64 * RADIX;
+        const uint partitionEnd = gid.x == e_threadBlocks - 1 ? e_numKeys : (gid.x + 1) * PARTITION_SIZE;
+        for (uint i = gtid.x + PARTITION_START; i < partitionEnd; i += UPSWEEP_THREADS)
+            InterlockedAdd(g_upsweepHist[(b_sort[i] >> radixShift & RADIX_MASK) + offset], 1);
     }
     GroupMemoryBarrierWithGroupSync();
     
-    //pass tile to pass histogram
+    //reduce and pass to tile histogram
     {
-        const int threadBlocks = e_threadBlocks;
-        for (int i = gtid.x; i < RADIX; i += UPSWEEP_THREADS)
+        const uint threadBlocks = e_threadBlocks;
+        for (uint i = gtid.x; i < RADIX; i += UPSWEEP_THREADS)
+        {
+            g_upsweepHist[i] += g_upsweepHist[i + RADIX];
             b_passHist[i * threadBlocks + gid.x] = g_upsweepHist[i];
+        }
     }
-    GroupMemoryBarrierWithGroupSync();
     
-    //exclusive prefix sum over the counts
+    //Larger 16 or greater can perform a more elegant scan because 16 * 16 = 256
+    if (WaveGetLaneCount() >= 16)
     {
-        const int laneMask = WaveGetLaneCount() - 1;
-        const int circularLaneShift = WaveGetLaneIndex() + 1 & laneMask;
-        for (int i = gtid.x; i < RADIX; i += UPSWEEP_THREADS)
-            g_upsweepHist[circularLaneShift + (i & ~laneMask)] = g_upsweepHist[i] + WavePrefixSum(g_upsweepHist[i]);
+        for (uint i = gtid.x; i < RADIX; i += UPSWEEP_THREADS)
+            g_upsweepHist[i] += WavePrefixSum(g_upsweepHist[i]);
+        GroupMemoryBarrierWithGroupSync();
+        
+        if (gtid.x < (RADIX / WaveGetLaneCount()))
+            g_upsweepHist[(gtid.x + 1) * WaveGetLaneCount() - 1] += WavePrefixSum(g_upsweepHist[(gtid.x + 1) * WaveGetLaneCount() - 1]);
+        GroupMemoryBarrierWithGroupSync();
+        
+        //atomically add to global histogram
+        const uint offset = e_radixShift << 5;
+        const uint laneMask = WaveGetLaneCount() - 1;
+        const uint circularLaneShift = WaveGetLaneIndex() + 1 & laneMask;
+        for (uint i = gtid.x; i < RADIX; i += UPSWEEP_THREADS)
+        {
+            const uint index = circularLaneShift + (i & ~laneMask);
+            InterlockedAdd(b_globalHist[index + offset], (WaveGetLaneIndex() != laneMask ? g_upsweepHist[i] : 0) +
+                (i >= WaveGetLaneCount() ? WaveReadLaneAt(g_upsweepHist[i - 1], 0) : 0));
+        }
     }
-    GroupMemoryBarrierWithGroupSync();
     
-    if (WaveGetLaneIndex() < (RADIX / WaveGetLaneCount()) && WAVE_INDEX == 0)
-        g_upsweepHist[WaveGetLaneIndex() * WaveGetLaneCount()] = WavePrefixSum(g_upsweepHist[WaveGetLaneIndex() * WaveGetLaneCount()]);
-    GroupMemoryBarrierWithGroupSync();
-    
-    //atomically add to global histogram
+    //Exclusive Brent-Kung with fused upsweep downsweep
+    if (WaveGetLaneCount() < 16)
     {
-        const int offset = e_radixShift << 5;
-        for (int i = gtid.x; i < RADIX; i += UPSWEEP_THREADS)
-            InterlockedAdd(b_globalHist[i + offset], (WaveGetLaneIndex() ? g_upsweepHist[i] : 0) + WaveReadLaneAt(g_upsweepHist[i], 0));
+        const uint deviceOffset = e_radixShift << 5;
+        for (uint i = gtid.x; i < RADIX; i += UPSWEEP_THREADS)
+            g_upsweepHist[i] += WavePrefixSum(g_upsweepHist[i]);
+        
+        if (gtid.x < WaveGetLaneCount())
+            InterlockedAdd(b_globalHist[gtid.x + deviceOffset], gtid.x ? g_upsweepHist[gtid.x - 1] : 0);
+        GroupMemoryBarrierWithGroupSync();
+        
+        const uint laneLog = countbits(WaveGetLaneCount() - 1);
+        uint offset = laneLog;
+        uint j = WaveGetLaneCount();
+        for (; j < (RADIX >> 1); j <<= laneLog)
+        {
+            for (uint i = gtid.x; i < (RADIX >> offset); i += UPSWEEP_THREADS)
+                g_upsweepHist[((i + 1) << offset) - 1] += WavePrefixSum(g_upsweepHist[((i + 1) << offset) - 1]);
+            GroupMemoryBarrierWithGroupSync();
+            
+            for (uint i = gtid.x + j; i < RADIX; i += UPSWEEP_THREADS)
+            {
+                if ((i & ((j << laneLog) - 1)) >= j)
+                {
+                    if (i < (j << laneLog) - 1)
+                    {
+                        InterlockedAdd(b_globalHist[i + deviceOffset],
+                            WaveReadLaneAt(g_upsweepHist[((i >> offset) << offset) - 1], 0) +
+                            ((i & (j - 1)) ? g_upsweepHist[i - 1] : 0));
+                    }
+                    else
+                    {
+                        if ((i + 1) & (j - 1))
+                            g_upsweepHist[i] += WaveReadLaneAt(g_upsweepHist[((i >> offset) << offset) - 1], 0);
+                    }
+                }
+            }
+            offset += laneLog;
+        }
+        GroupMemoryBarrierWithGroupSync();
+        
+        for (uint i = gtid.x + j; i < RADIX; i += UPSWEEP_THREADS)
+        {
+            InterlockedAdd(b_globalHist[i + deviceOffset],
+                WaveReadLaneAt(g_upsweepHist[((i >> offset) << offset) - 1], 0) +
+                ((i & (j - 1)) ? g_upsweepHist[i - 1] : 0));
+        }
     }
 }
 
@@ -132,173 +186,418 @@ void Upsweep(int3 gtid : SV_GroupThreadID, int3 gid : SV_GroupID)
 [numthreads(SCAN_THREADS, 1, 1)]
 void Scan(int3 gtid : SV_GroupThreadID, int3 gid : SV_GroupID)
 {
-    uint aggregate = 0;
-    const int threadBlocks = e_threadBlocks;
-    const int tBlocksEnd = (threadBlocks + WaveGetLaneCount() - 1) / WaveGetLaneCount() * WaveGetLaneCount();
-    const int laneMask = WaveGetLaneCount() - 1;
-    const int circularLaneShift = WaveGetLaneIndex() + 1 & laneMask;
-    const int offset = (gid.x * (SCAN_THREADS / WaveGetLaneCount()) + WAVE_INDEX) * threadBlocks;
-    
-    for (int i = WaveGetLaneIndex(); i < tBlocksEnd; i += WaveGetLaneCount())
+    if (WaveGetLaneCount() >= 16)
     {
-        uint t;
-        if (i < threadBlocks)
-            t = b_passHist[i + offset];
-        t += WavePrefixSum(t);
-        const int index = circularLaneShift + (i & ~laneMask);
-        if (index < threadBlocks)
-            b_passHist[index + offset] = (WaveGetLaneIndex() != laneMask ? t : 0) + aggregate;
-        aggregate += WaveReadLaneAt(t, laneMask);
+        uint aggregate = 0;
+        const uint laneMask = WaveGetLaneCount() - 1;
+        const uint circularLaneShift = WaveGetLaneIndex() + 1 & laneMask;
+        const uint partionsEnd = e_threadBlocks / SCAN_THREADS * SCAN_THREADS;
+        const uint offset = gid.x * e_threadBlocks;
+        uint i = gtid.x;
+        for (; i < partionsEnd; i += SCAN_THREADS)
+        {
+            g_scanMem[gtid.x] = b_passHist[i + offset];
+            g_scanMem[gtid.x] += WavePrefixSum(g_scanMem[gtid.x]);
+            GroupMemoryBarrierWithGroupSync();
+            
+            if (gtid.x < SCAN_THREADS / WaveGetLaneCount())
+                g_scanMem[(gtid.x + 1) * WaveGetLaneCount() - 1] += WavePrefixSum(g_scanMem[(gtid.x + 1) * WaveGetLaneCount() - 1]);
+            GroupMemoryBarrierWithGroupSync();
+            
+            b_passHist[circularLaneShift + (i & ~laneMask) + offset] = (WaveGetLaneIndex() != laneMask ? g_scanMem[gtid.x] : 0) +
+                (gtid.x >= WaveGetLaneCount() ? WaveReadLaneAt(g_scanMem[gtid.x - 1], 0) : 0) + aggregate;
+
+            aggregate += g_scanMem[UPSWEEP_THREADS - 1];
+            GroupMemoryBarrierWithGroupSync();
+        }
+        
+        //partial
+        if (i < e_threadBlocks)
+            g_scanMem[gtid.x] = b_passHist[offset + i];
+        g_scanMem[gtid.x] += WavePrefixSum(g_scanMem[gtid.x]);
+        GroupMemoryBarrierWithGroupSync();
+            
+        if (gtid.x < SCAN_THREADS / WaveGetLaneCount())
+            g_scanMem[(gtid.x + 1) * WaveGetLaneCount() - 1] += WavePrefixSum(g_scanMem[(gtid.x + 1) * WaveGetLaneCount() - 1]);
+        GroupMemoryBarrierWithGroupSync();
+        
+        const uint index = circularLaneShift + (i & ~laneMask);
+        if (index < e_threadBlocks)
+        {
+            b_passHist[index + offset] = (WaveGetLaneIndex() != laneMask ? g_scanMem[gtid.x] : 0) +
+                (gtid.x >= WaveGetLaneCount() ? WaveReadLaneAt(g_scanMem[gtid.x - 1], 0) : 0) + aggregate;
+        }
+    }
+
+    if (WaveGetLaneCount() < 16)
+    {
+        uint aggregate = 0;
+        const uint partitions = e_threadBlocks / SCAN_THREADS;
+        const uint deviceOffset = gid.x * e_threadBlocks;
+        const uint laneLog = countbits(WaveGetLaneCount() - 1);
+        
+        uint k = 0;
+        for (; k < partitions; ++k)
+        {
+            g_scanMem[gtid.x] = b_passHist[gtid.x + k * SCAN_THREADS + deviceOffset];
+            g_scanMem[gtid.x] += WavePrefixSum(g_scanMem[gtid.x]);
+            
+            if (gtid.x < WaveGetLaneCount())
+                b_passHist[gtid.x + k * SCAN_THREADS + deviceOffset] = (gtid.x ? g_scanMem[gtid.x - 1] : 0) + aggregate;
+            GroupMemoryBarrierWithGroupSync();
+            
+            uint offset = laneLog;
+            uint j = WaveGetLaneCount();
+            for (; j < (SCAN_THREADS >> 1); j <<= laneLog)
+            {
+                for (uint i = gtid.x; i < (SCAN_THREADS >> offset); i += SCAN_THREADS)
+                    g_scanMem[((i + 1) << offset) - 1] += WavePrefixSum(g_scanMem[((i + 1) << offset) - 1]);
+                GroupMemoryBarrierWithGroupSync();
+            
+                for (uint i = gtid.x + j; i < SCAN_THREADS; i += SCAN_THREADS)
+                {
+                    if ((i & ((j << laneLog) - 1)) >= j)
+                    {
+                        if (i < (j << laneLog) - 1)
+                        {
+                            b_passHist[i + k * SCAN_THREADS + deviceOffset] = WaveReadLaneAt(g_scanMem[((i >> offset) << offset) - 1], 0) +
+                            ((i & (j - 1)) ? g_scanMem[i - 1] : 0) + aggregate;
+                        }
+                        else
+                        {
+                            if ((i + 1) & (j - 1))
+                                g_scanMem[i] += WaveReadLaneAt(g_scanMem[((i >> offset) << offset) - 1], 0);
+                        }
+                    }
+                }
+                offset += laneLog;
+            }
+            GroupMemoryBarrierWithGroupSync();
+        
+            for (uint i = gtid.x + j; i < SCAN_THREADS; i += SCAN_THREADS)
+            {
+                b_passHist[i + k * SCAN_THREADS + deviceOffset] = WaveReadLaneAt(g_scanMem[((i >> offset) << offset) - 1], 0) +
+                            ((i & (j - 1)) ? g_scanMem[i - 1] : 0) + aggregate;
+            }
+            
+            aggregate += WaveReadLaneAt(g_scanMem[SCAN_THREADS - 1], 0);
+            GroupMemoryBarrierWithGroupSync();
+        }
+        
+        //partial
+        const uint finalPartSize = e_threadBlocks - k * SCAN_THREADS;
+        if (gtid.x < finalPartSize)
+        {
+            g_scanMem[gtid.x] = b_passHist[gtid.x + k * SCAN_THREADS + deviceOffset];
+            g_scanMem[gtid.x] += WavePrefixSum(g_scanMem[gtid.x]);
+            
+            if (gtid.x < WaveGetLaneCount())
+                b_passHist[gtid.x + k * SCAN_THREADS + deviceOffset] = (gtid.x ? g_scanMem[gtid.x - 1] : 0) + aggregate;
+        }
+        GroupMemoryBarrierWithGroupSync();
+        
+        uint offset = laneLog;
+        for (uint j = WaveGetLaneCount(); j < finalPartSize; j <<= laneLog)
+        {
+            for (uint i = gtid.x; i < (finalPartSize >> offset); i += SCAN_THREADS)
+                g_scanMem[((i + 1) << offset) - 1] += WavePrefixSum(g_scanMem[((i + 1) << offset) - 1]);
+            GroupMemoryBarrierWithGroupSync();
+            
+            for (uint i = gtid.x + j; i < finalPartSize; i += SCAN_THREADS)
+            {
+                if ((i & ((j << laneLog) - 1)) >= j)
+                {
+                    if (i < (j << laneLog) - 1)
+                    {
+                        b_passHist[i + k * SCAN_THREADS + deviceOffset] = WaveReadLaneAt(g_scanMem[((i >> offset) << offset) - 1], 0) +
+                            ((i & (j - 1)) ? g_scanMem[i - 1] : 0) + aggregate;
+                    }
+                    else
+                    {
+                        if ((i + 1) & (j - 1))
+                            g_scanMem[i] += WaveReadLaneAt(g_scanMem[((i >> offset) << offset) - 1], 0);
+                    }
+                }
+            }
+            offset += laneLog;
+        }
     }
 }
 
 [numthreads(DS_THREADS, 1, 1)]
 void Downsweep(int3 gtid : SV_GroupThreadID, int3 gid : SV_GroupID)
 {
-    //load the global and pass histogram values into shared memory
-    if (gtid.x < RADIX)
-        g_localHist[gtid.x] = b_globalHist[gtid.x + (e_radixShift << 5)] + b_passHist[gtid.x * e_threadBlocks + gid.x];
-    
-    //Each wave clears its own portion of shared memory
-    {
-        const int waveHistEnd = (WAVE_INDEX + 1) * RADIX;
-        for (int i = WaveGetLaneIndex() + WAVE_INDEX * RADIX; i < waveHistEnd; i += WaveGetLaneCount())
-            g_waveHists[i] = 0;
-    }
-    GroupMemoryBarrierWithGroupSync();
-    
     if (gid.x != e_threadBlocks - 1)
     {
-        //Load keys into registers
         uint keys[DS_KEYS_PER_THREAD];
-        [unroll]
-        for (int i = 0, t = WaveGetLaneIndex() + DS_WAVE_PART_START + PARTITION_START; i < DS_KEYS_PER_THREAD; ++i, t += WaveGetLaneCount())
-            keys[i] = b_sort[t];
-
-        //Warp Level Multisplit, should support SIMD width up to 128
         uint offsets[DS_KEYS_PER_THREAD];
+        uint exclusiveWaveReduction;
+        
+        //Load keys into registers
+        [unroll]
+        for (uint i = 0, t = WaveGetLaneIndex() + DS_WAVE_PART_START + PARTITION_START; i < DS_KEYS_PER_THREAD; ++i, t += WaveGetLaneCount())
+            keys[i] = b_sort[t];
+        
+        if (WaveGetLaneCount() >= 16)
         {
-            const uint waveParts = WaveGetLaneCount() / 32;
-            uint4 waveFlags;
-            
-            [unroll]
-            for (int i = 0; i < DS_KEYS_PER_THREAD; ++i)
+            //Clear histogram memory
             {
-                waveFlags = 0xffffffff;
+                const uint downsweepHists = DS_HISTS_SIZE;
+                for (uint i = gtid.x; i < downsweepHists; i += DS_THREADS)
+                    g_dsMem[i] = 0;
+            }
+            GroupMemoryBarrierWithGroupSync();
 
-                for (int k = e_radixShift; k < e_radixShift + RADIX_LOG; ++k)
+            //Warp Level Multisplit, should support SIMD width up to 128
+            {
+                const uint waveParts = (WaveGetLaneCount() + 31) / 32;
+                uint4 waveFlags;
+            
+                [unroll]
+                for (uint i = 0; i < DS_KEYS_PER_THREAD; ++i)
+                {
+                    waveFlags = 0xffffffff;
+
+                    for (uint k = e_radixShift; k < e_radixShift + RADIX_LOG; ++k)
+                    {
+                        const bool t = keys[i] >> k & 1;
+                        const uint4 ballot = WaveActiveBallot(t);
+                        for (int wavePart = 0; wavePart < waveParts; ++wavePart)
+                            waveFlags[wavePart] &= (t ? 0 : 0xffffffff) ^ ballot[wavePart];
+                    }
+                
+                    uint bits = 0;
+                    for (uint wavePart = 0; wavePart < waveParts; ++wavePart)
+                    {
+                        //%lanemask_le
+                        if (WaveGetLaneIndex() >= wavePart * 32)
+                        {
+                            const uint leMask = WaveGetLaneIndex() >= ((wavePart + 1) * 32) - 1 ? 0xffffffff :
+                            (1U << ((WaveGetLaneIndex() & 31) + 1)) - 1;
+                            bits += countbits(waveFlags[wavePart] & leMask);
+                        }
+                    }
+                    
+                    const uint index = (keys[i] >> e_radixShift & RADIX_MASK) + (WAVE_INDEX * RADIX);
+                    offsets[i] = g_dsMem[index] + bits - 1;
+                    
+                    GroupMemoryBarrierWithGroupSync();
+                    if (bits == 1)
+                    {
+                        for (uint wavePart = 0; wavePart < waveParts; ++wavePart)
+                            g_dsMem[index] += countbits(waveFlags[wavePart]);
+                    }
+                    GroupMemoryBarrierWithGroupSync();
+                }
+            }
+            
+            //inclusive/exclusive prefix sum up the histograms
+            //followed by exclusive prefix sum across the reductions
+            {
+                uint reduction;
+                if (gtid.x < RADIX)
+                {
+                    reduction = g_dsMem[gtid.x];
+                    for (uint i = gtid.x + RADIX; i < DS_HISTS_SIZE; i += RADIX)
+                    {
+                        reduction += g_dsMem[i];
+                        g_dsMem[i] = reduction - g_dsMem[i];
+                    }
+                    reduction += WavePrefixSum(reduction);
+                }
+                GroupMemoryBarrierWithGroupSync();
+
+                if (gtid.x < RADIX)
+                {
+                    const uint laneMask = WaveGetLaneCount() - 1;
+                    g_dsMem[((WaveGetLaneIndex() + 1) & laneMask) + (gtid.x & ~laneMask)] = reduction;
+                }
+                GroupMemoryBarrierWithGroupSync();
+                
+                if (gtid.x < RADIX / WaveGetLaneCount())
+                    g_dsMem[gtid.x * WaveGetLaneCount()] = WavePrefixSum(g_dsMem[gtid.x * WaveGetLaneCount()]);
+                GroupMemoryBarrierWithGroupSync();
+                
+                if (gtid.x < RADIX && WaveGetLaneIndex())
+                    g_dsMem[gtid.x] += WaveReadLaneAt(g_dsMem[gtid.x - 1], 1);
+            }
+            GroupMemoryBarrierWithGroupSync();
+        
+            //Update offsets
+            if (gtid.x >= WaveGetLaneCount())
+            {
+                const uint t = WAVE_INDEX * RADIX;
+                [unroll]
+                for (uint i = 0; i < DS_KEYS_PER_THREAD; ++i)
+                {
+                    const uint t2 = keys[i] >> e_radixShift & RADIX_MASK;
+                    offsets[i] += g_dsMem[t2 + t] + g_dsMem[t2];
+                }
+            }
+            else
+            {
+                [unroll]
+                for (uint i = 0; i < DS_KEYS_PER_THREAD; ++i)
+                    offsets[i] += g_dsMem[keys[i] >> e_radixShift & RADIX_MASK];
+            }
+            
+            //take advantage of barrier
+            exclusiveWaveReduction = g_dsMem[gtid.x];
+            GroupMemoryBarrierWithGroupSync();
+        }
+        
+        if (WaveGetLaneCount() < 16)
+        {
+            //clear shared memory
+            for (uint i = gtid.x; i < MAX_DS_SMEM; i += DS_THREADS)
+                g_dsMem[i] = 0;
+            GroupMemoryBarrierWithGroupSync();
+            
+            uint waveFlag;
+            uint leMask = (1U << (WaveGetLaneIndex() + 1)) - 1; //works because we are guarunteeing that waves < 32, else 1 << 32 breaks
+            leMask = leMask ? leMask : 0xffffffff; //remove this later, safety for when testing with wave width 32+
+            
+            //if wave == 4 this will be serialized, as there is not enough room
+            [unroll]
+            for (uint i = 0; i < DS_KEYS_PER_THREAD; ++i)
+            {
+                waveFlag = 0xffffffff;
+                
+                for (uint k = e_radixShift; k < e_radixShift + RADIX_LOG; ++k)
                 {
                     const bool t = keys[i] >> k & 1;
-                    const uint4 ballot = WaveActiveBallot(t);
-                    for (int wavePart = 0; wavePart < waveParts; ++wavePart)
-                        waveFlags[wavePart] &= (t ? 0 : 0xffffffff) ^ ballot[wavePart];
+                    waveFlag &= (t ? 0 : 0xffffffff) ^ WaveActiveBallot(t);
                 }
                 
-                uint bits = 0;
-                for (int wavePart = 0; wavePart < waveParts; ++wavePart)
+                uint bits = countbits(waveFlag & leMask);
+                const uint index = (keys[i] >> (e_radixShift + 1) & HALF_MASK) + (WAVE_INDEX * HALF_RADIX);
+                
+                offsets[i] = (g_dsMem[index] >> ((keys[i] >> e_radixShift & 1) ? 16 : 0) & 0xffff) + bits - 1;
+                    
+                GroupMemoryBarrierWithGroupSync();
+                if (bits == 1)
+                    InterlockedAdd(g_dsMem[index], countbits(waveFlag) << ((keys[i] >> e_radixShift & 1) ? 16 : 0));
+                GroupMemoryBarrierWithGroupSync();
+            }
+            
+            //inclusive/exclusive prefix sum up the histograms,
+            //use a blelloch scan for in place exclusive
+            {
+                uint reduction;
+                if (gtid.x < HALF_RADIX)
                 {
-                    //%lanemask_le, but gross
-                    if (WaveGetLaneIndex() >= (wavePart << 5))
+                    reduction = g_dsMem[gtid.x];
+                    for (uint i = gtid.x + HALF_RADIX; i < MAX_DS_SMEM; i += HALF_RADIX)
                     {
-                        const uint leMask = WaveGetLaneIndex() >= ((wavePart + 1) << 5) - 1 ? 0xffffffff :
-                            (1 << (WaveGetLaneIndex() & 31) + 1) - 1;
-                        bits += countbits(waveFlags[wavePart] & leMask);
+                        reduction += g_dsMem[i];
+                        g_dsMem[i] = reduction - g_dsMem[i];
+                    }
+                    g_dsMem[gtid.x] = reduction;
+                }
+                GroupMemoryBarrierWithGroupSync();
+
+                if (gtid.x < HALF_RADIX)
+                    g_dsMem[gtid.x] += g_dsMem[gtid.x] << 16;
+                
+                uint shift = 1;
+                for (uint j = RADIX >> 2; j > 0; j >>= 1)
+                {
+                    GroupMemoryBarrierWithGroupSync();
+                    for (int i = gtid.x; i < j; i += UPSWEEP_THREADS)
+                        g_dsMem[((((i << 1) + 2) << shift) - 1) >> 1] += g_dsMem[((((i << 1) + 1) << shift) - 1) >> 1] & 0xffff0000;
+                    shift++;
+                }
+                GroupMemoryBarrierWithGroupSync();
+                
+                if (gtid.x == 0)
+                    g_dsMem[HALF_RADIX - 1] &= 0xffff;
+                
+                for (uint j = 1; j < RADIX >> 1; j <<= 1)
+                {
+                    --shift;
+                    GroupMemoryBarrierWithGroupSync();
+                    for (uint i = gtid.x; i < j; i += UPSWEEP_THREADS)
+                    {
+                        const uint t = ((((i << 1) + 1) << shift) - 1) >> 1;
+                        const uint t2 = ((((i << 1) + 2) << shift) - 1) >> 1;
+                        const uint t3 = g_dsMem[t];
+                        g_dsMem[t] = (g_dsMem[t] & 0xffff) | (g_dsMem[t2] & 0xffff0000);
+                        g_dsMem[t2] += t3 & 0xffff0000;
                     }
                 }
-                    
-                const int index = (keys[i] >> e_radixShift & RADIX_MASK) + (WAVE_INDEX * RADIX);
-                offsets[i] = g_waveHists[index] + bits - 1;
-                if (bits == 1)
+
+                GroupMemoryBarrierWithGroupSync();
+                if (gtid.x < HALF_RADIX)
                 {
-                    for (int wavePart = 0; wavePart < waveParts; ++wavePart)
-                        g_waveHists[index] += countbits(waveFlags[wavePart]);
+                    const uint t = g_dsMem[gtid.x];
+                    g_dsMem[gtid.x] = (t >> 16) + (t << 16) + (t & 0xffff0000);
                 }
                 GroupMemoryBarrierWithGroupSync();
             }
-        }
-        
-        //exclusive prefix sum across the histograms
-        if (gtid.x < RADIX)
-        {
-            for (int k = gtid.x + RADIX; k < DS_HISTS_SIZE; k += RADIX)
+            
+            //Update offsets
+            if (gtid.x >= WaveGetLaneCount())
             {
-                g_waveHists[gtid.x] += g_waveHists[k];
-                g_waveHists[k] = g_waveHists[gtid.x] - g_waveHists[k];
+                const uint t = WAVE_INDEX * HALF_RADIX;
+                [unroll]
+                for (uint i = 0; i < DS_KEYS_PER_THREAD; ++i)
+                {
+                    const uint t2 = keys[i] >> (e_radixShift + 1) & HALF_MASK;
+                    offsets[i] += (g_dsMem[t2 + t] + g_dsMem[t2]) >> ((keys[i] >> e_radixShift & 1) ? 16 : 0) & 0xffff;
+                }
             }
-        }
-        GroupMemoryBarrierWithGroupSync();
-
-        //exclusive prefix sum across the reductions
-        {
-            const uint t = (WaveGetLaneIndex() + 1 & WaveGetLaneCount() - 1) + (WAVE_INDEX * WaveGetLaneCount());
+            else
+            {
+                [unroll]
+                for (uint i = 0; i < DS_KEYS_PER_THREAD; ++i)
+                    offsets[i] += g_dsMem[keys[i] >> (e_radixShift + 1) & HALF_MASK] >> ((keys[i] >> e_radixShift & 1) ? 16 : 0) & 0xffff;
+            }
+            
             if (gtid.x < RADIX)
-                g_waveHists[t] = WavePrefixSum(g_waveHists[gtid.x]) + g_waveHists[gtid.x];
+                exclusiveWaveReduction = g_dsMem[gtid.x >> 1] >> ((gtid.x & 1) ? 16 : 0) & 0xffff;
             GroupMemoryBarrierWithGroupSync();
-        
-            if (WaveGetLaneIndex() < (RADIX / WaveGetLaneCount()) && WAVE_INDEX == 0)
-                g_waveHists[WaveGetLaneIndex() * WaveGetLaneCount()] =
-                WavePrefixSum(g_waveHists[WaveGetLaneIndex() * WaveGetLaneCount()]);
-            GroupMemoryBarrierWithGroupSync();
-
-            if (gtid.x < RADIX)
-            {
-                if (WaveGetLaneIndex())
-                    g_waveHists[gtid.x] += WaveReadLaneAt(g_waveHists[gtid.x - 1], 1);
-                g_localHist[gtid.x] -= g_waveHists[gtid.x];
-            }
         }
-        GroupMemoryBarrierWithGroupSync();
-        
-        //Update offsets
-        if (gtid.x >= WaveGetLaneCount())
-        {
-            const uint t = WAVE_INDEX * RADIX;
-            [unroll]
-            for (int i = 0; i < DS_KEYS_PER_THREAD; ++i)
-            {
-                const uint t2 = keys[i] >> e_radixShift & RADIX_MASK;
-                offsets[i] += g_waveHists[t2 + t] + g_waveHists[t2];
-            }
-        }
-        else
-        {
-            [unroll]
-            for (int i = 0; i < DS_KEYS_PER_THREAD; ++i)
-                offsets[i] += g_waveHists[keys[i] >> e_radixShift & RADIX_MASK];
-        }
-        GroupMemoryBarrierWithGroupSync();
         
         //scatter keys into shared memory
-        for (int i = 0; i < DS_KEYS_PER_THREAD; ++i)
-            g_waveHists[offsets[i]] = keys[i];
+        for (uint i = 0; i < DS_KEYS_PER_THREAD; ++i)
+            g_dsMem[offsets[i]] = keys[i];
+        
+        if (gtid.x < RADIX)
+            g_dsMem[gtid.x + PARTITION_SIZE] = b_globalHist[gtid.x + (e_radixShift << 5)] + b_passHist[gtid.x * e_threadBlocks + gid.x] - exclusiveWaveReduction;
         GroupMemoryBarrierWithGroupSync();
         
         //scatter runs of keys into device memory, 
         //store the scatter location in the key register to reuse for the payload
         [unroll]
-        for (int i = 0, t = WaveGetLaneIndex() + DS_WAVE_PART_START; i < DS_KEYS_PER_THREAD; ++i, t += WaveGetLaneCount())
+        for (uint i = 0, t = WaveGetLaneIndex() + DS_WAVE_PART_START; i < DS_KEYS_PER_THREAD; ++i, t += WaveGetLaneCount())
         {
-            keys[i] = g_localHist[g_waveHists[t] >> e_radixShift & RADIX_MASK] + t;
-            b_alt[keys[i]] = g_waveHists[t];
+            keys[i] = g_dsMem[(g_dsMem[t] >> e_radixShift & RADIX_MASK) + PARTITION_SIZE] + t;
+            b_alt[keys[i]] = g_dsMem[t];
         }
         GroupMemoryBarrierWithGroupSync();
         
         //Scatter payloads directly into shared memory
         [unroll]
-        for (int i = 0, t = WaveGetLaneIndex() + DS_WAVE_PART_START + PARTITION_START; i < DS_KEYS_PER_THREAD; ++i, t += WaveGetLaneCount())
-            g_waveHists[offsets[i]] = b_sortPayload[t];
+        for (uint i = 0, t = WaveGetLaneIndex() + DS_WAVE_PART_START + PARTITION_START; i < DS_KEYS_PER_THREAD; ++i, t += WaveGetLaneCount())
+            g_dsMem[offsets[i]] = b_sortPayload[t];
         GroupMemoryBarrierWithGroupSync();
         
         //Scatter runs of payloads into device memory
         [unroll]
-        for (int i = 0, t = WaveGetLaneIndex() + DS_WAVE_PART_START; i < DS_KEYS_PER_THREAD; ++i, t += WaveGetLaneCount())
-            b_altPayload[keys[i]] = g_waveHists[t];
+        for (uint i = 0, t = WaveGetLaneIndex() + DS_WAVE_PART_START; i < DS_KEYS_PER_THREAD; ++i, t += WaveGetLaneCount())
+            b_altPayload[keys[i]] = g_dsMem[t];
     }
-    else
+    
+    //perform the sort on the final partition slightly differently 
+    //to handle input sizes not perfect multiples of the partition
+    if (gid.x == e_threadBlocks - 1)
     {
-        //perform the sort on the final partition slightly differently 
-        //to handle input sizes not perfect multiples of the partition
-        const uint waveParts = WaveGetLaneCount() / 32;
+        //load the global and pass histogram values into shared memory
+        if (gtid.x < RADIX)
+            g_dsMem[gtid.x] = b_globalHist[gtid.x + (e_radixShift << 5)] + b_passHist[gtid.x * e_threadBlocks + gid.x];
+        GroupMemoryBarrierWithGroupSync();
+        
+        const uint waveParts = (WaveGetLaneCount() + 31) / 32;
         for (int i = gtid.x + PARTITION_START; i < PARTITION_START + PARTITION_SIZE; i += DS_THREADS)
         {
             const uint key = b_sort[i];
@@ -321,7 +620,7 @@ void Downsweep(int3 gtid : SV_GroupThreadID, int3 gid : SV_GroupID)
                     if (WaveGetLaneIndex() >= wavePart * 32)
                     {
                         const uint leMask = WaveGetLaneIndex() >= ((wavePart + 1) * 32) - 1 ? 0xffffffff :
-                            (1 << (WaveGetLaneIndex() & 31) + 1) - 1;
+                            (1U << ((WaveGetLaneIndex() & 31) + 1)) - 1;
                         bits += countbits(waveFlags[wavePart] & leMask);
                     }
                 }
@@ -330,13 +629,13 @@ void Downsweep(int3 gtid : SV_GroupThreadID, int3 gid : SV_GroupID)
             for (int k = 0; k < DS_THREADS / WaveGetLaneCount(); ++k)
             {
                 if (WAVE_INDEX == k && i < e_numKeys)
+                    offset = g_dsMem[key >> e_radixShift & RADIX_MASK] + bits - 1;
+                GroupMemoryBarrierWithGroupSync();
+                
+                if (WAVE_INDEX == k && i < e_numKeys && bits == 1)
                 {
-                    offset = g_localHist[key >> e_radixShift & RADIX_MASK] + bits - 1;
-                    if (bits == 1)
-                    {
-                        for (int wavePart = 0; wavePart < waveParts; ++wavePart)
-                            g_localHist[key >> e_radixShift & RADIX_MASK] += countbits(waveFlags[wavePart]);
-                    }
+                    for (int wavePart = 0; wavePart < waveParts; ++wavePart)
+                        g_dsMem[key >> e_radixShift & RADIX_MASK] += countbits(waveFlags[wavePart]);
                 }
                 GroupMemoryBarrierWithGroupSync();
             }

--- a/package/Shaders/DeviceRadixSort.hlsl.meta
+++ b/package/Shaders/DeviceRadixSort.hlsl.meta
@@ -1,0 +1,7 @@
+fileFormatVersion: 2
+guid: 02209b8d952e7fc418492b88139826fd
+ShaderIncludeImporter:
+  externalObjects: {}
+  userData: 
+  assetBundleName: 
+  assetBundleVariant: 

--- a/package/Shaders/SplatUtilities.compute
+++ b/package/Shaders/SplatUtilities.compute
@@ -19,7 +19,6 @@
 
 // DeviceRadixSort
 #pragma kernel InitDeviceRadixSort
-#pragma kernel PollWaveSize
 #pragma kernel Upsweep
 #pragma kernel Scan
 #pragma kernel Downsweep

--- a/package/Shaders/SplatUtilities.compute
+++ b/package/Shaders/SplatUtilities.compute
@@ -17,19 +17,19 @@
 #pragma kernel CSExportData
 #pragma kernel CSCopySplats
 
-// FidelityFX GPU sorting
-#pragma kernel FfxParallelSortReduce
-#pragma kernel FfxParallelSortScanAdd
-#pragma kernel FfxParallelSortScan
-#pragma kernel FfxParallelSortScatter
-#pragma kernel FfxParallelSortCount
+// DeviceRadixSort
+#pragma kernel InitDeviceRadixSort
+#pragma kernel PollWaveSize
+#pragma kernel Upsweep
+#pragma kernel Scan
+#pragma kernel Downsweep
 
 // GPU sorting needs wave ops
 #pragma require wavebasic
 
 #pragma use_dxc
 
-#include "GpuSortFidelityFX.hlsl"
+#include "DeviceRadixSort.hlsl"
 #include "GaussianSplatting.hlsl"
 
 float4x4 _MatrixObjectToWorld;

--- a/projects/GaussianExample/Assets/GSTestScene.unity
+++ b/projects/GaussianExample/Assets/GSTestScene.unity
@@ -338,10 +338,11 @@ MonoBehaviour:
   m_Script: {fileID: 11500000, guid: c12d929a7f62c48adbe9ff45c9a33ff0, type: 3}
   m_Name: 
   m_EditorClassIdentifier: 
-  m_Asset: {fileID: -4308533957279737314, guid: ffd797c1fd4a04ba9998316b8b0189d6, type: 3}
+  m_Asset: {fileID: 11400000, guid: 4317a613eb53b6c4a9996873a734dad3, type: 2}
   m_SplatScale: 1
   m_OpacityScale: 1
   m_SHOrder: 3
+  m_SHOnly: 0
   m_SortNthFrame: 1
   m_RenderMode: 0
   m_PointDisplaySize: 3


### PR DESCRIPTION
Add DeviceRadixSort (MIT License). Keep FidelityFX as a fallback, but modify host CPU code to use DeviceRadixSort. DeviceRadixSort still untested on AMD hardware. See issue https://github.com/aras-p/UnityGaussianSplatting/issues/48.