### PR TITLE
VR support

### DIFF
--- a/package/Runtime/GaussianSplatRenderer.cs
+++ b/package/Runtime/GaussianSplatRenderer.cs
@@ -301,9 +301,7 @@ namespace GaussianSplatting.Runtime
             public static readonly int SrcBuffer = Shader.PropertyToID("_SrcBuffer");
             public static readonly int DstBuffer = Shader.PropertyToID("_DstBuffer");
             public static readonly int BufferSize = Shader.PropertyToID("_BufferSize");
-            public static readonly int MatrixVP = Shader.PropertyToID("_MatrixVP");
             public static readonly int MatrixMV = Shader.PropertyToID("_MatrixMV");
-            public static readonly int MatrixP = Shader.PropertyToID("_MatrixP");
             public static readonly int MatrixObjectToWorld = Shader.PropertyToID("_MatrixObjectToWorld");
             public static readonly int MatrixWorldToObject = Shader.PropertyToID("_MatrixWorldToObject");
             public static readonly int VecScreenParams = Shader.PropertyToID("_VecScreenParams");
@@ -558,9 +556,7 @@ namespace GaussianSplatting.Runtime
             // calculate view dependent data for each splat
             SetAssetDataOnCS(cmb, KernelIndices.CalcViewData);
 
-            cmb.SetComputeMatrixParam(m_CSSplatUtilities, Props.MatrixVP, matProj * matView);
             cmb.SetComputeMatrixParam(m_CSSplatUtilities, Props.MatrixMV, matView * matO2W);
-            cmb.SetComputeMatrixParam(m_CSSplatUtilities, Props.MatrixP, matProj);
             cmb.SetComputeMatrixParam(m_CSSplatUtilities, Props.MatrixObjectToWorld, matO2W);
             cmb.SetComputeMatrixParam(m_CSSplatUtilities, Props.MatrixWorldToObject, matW2O);
 
@@ -784,9 +780,7 @@ namespace GaussianSplatting.Runtime
             using var cmb = new CommandBuffer { name = "SplatSelectionUpdate" };
             SetAssetDataOnCS(cmb, KernelIndices.SelectionUpdate);
 
-            cmb.SetComputeMatrixParam(m_CSSplatUtilities, Props.MatrixVP, matProj * matView);
             cmb.SetComputeMatrixParam(m_CSSplatUtilities, Props.MatrixMV, matView * matO2W);
-            cmb.SetComputeMatrixParam(m_CSSplatUtilities, Props.MatrixP, matProj);
             cmb.SetComputeMatrixParam(m_CSSplatUtilities, Props.MatrixObjectToWorld, matO2W);
             cmb.SetComputeMatrixParam(m_CSSplatUtilities, Props.MatrixWorldToObject, matW2O);
 

--- a/package/Runtime/GaussianSplatRenderer.cs
+++ b/package/Runtime/GaussianSplatRenderer.cs
@@ -10,6 +10,7 @@ using Unity.Profiling.LowLevel;
 using UnityEngine;
 using UnityEngine.Experimental.Rendering;
 using UnityEngine.Rendering;
+using UnityEngine.XR;
 
 namespace GaussianSplatting.Runtime
 {
@@ -550,7 +551,8 @@ namespace GaussianSplatting.Runtime
             Matrix4x4 matO2W = tr.localToWorldMatrix;
             Matrix4x4 matW2O = tr.worldToLocalMatrix;
             int screenW = cam.pixelWidth, screenH = cam.pixelHeight;
-            Vector4 screenPar = new Vector4(screenW, screenH, 0, 0);
+            int eyeW = XRSettings.eyeTextureWidth, eyeH = XRSettings.eyeTextureHeight;
+            Vector4 screenPar = new Vector4(eyeW != 0 ? eyeW : screenW, eyeH != 0 ? eyeH : screenH, 0, 0);
             Vector4 camPos = cam.transform.position;
 
             // calculate view dependent data for each splat

--- a/package/Runtime/GpuSorting.cs
+++ b/package/Runtime/GpuSorting.cs
@@ -5,7 +5,7 @@ using UnityEngine.Rendering;
 namespace GaussianSplatting.Runtime
 {
     // GPU (uint key, uint payload) 8 bit-LSD radix sort, using reduce-then-scan
-    // Copyright Thomas Smith 2023, MIT license
+    // Copyright Thomas Smith 2024, MIT license
     // https://github.com/b0nes164/GPUSorting
 
     public class GpuSorting
@@ -21,6 +21,13 @@ namespace GaussianSplatting.Runtime
 
         //Number of sorting passes required to sort a 32bit key, KEY_BITS / DEVICE_RADIX_SORT_BITS
         const uint DEVICE_RADIX_SORT_PASSES = 4;
+
+        //Keywords to enable for the shader
+        private LocalKeyword m_keyUintKeyword;
+        private LocalKeyword m_payloadUintKeyword;
+        private LocalKeyword m_ascendKeyword;
+        private LocalKeyword m_sortPairKeyword;
+        private LocalKeyword m_vulkanKeyword;
 
         public struct Args
         {
@@ -104,6 +111,21 @@ namespace GaussianSplatting.Runtime
                     m_Valid = false;
                 }
             }
+
+            m_keyUintKeyword = new LocalKeyword(cs, "KEY_UINT");
+            m_payloadUintKeyword = new LocalKeyword(cs, "PAYLOAD_UINT");
+            m_ascendKeyword = new LocalKeyword(cs, "SHOULD_ASCEND");
+            m_sortPairKeyword = new LocalKeyword(cs, "SORT_PAIRS");
+            m_vulkanKeyword = new LocalKeyword(cs, "VULKAN");
+
+            cs.EnableKeyword(m_keyUintKeyword);
+            cs.EnableKeyword(m_payloadUintKeyword);
+            cs.EnableKeyword(m_ascendKeyword);
+            cs.EnableKeyword(m_sortPairKeyword);
+            if (SystemInfo.graphicsDeviceType == UnityEngine.Rendering.GraphicsDeviceType.Vulkan)
+                cs.EnableKeyword(m_vulkanKeyword);
+            else
+                cs.DisableKeyword(m_vulkanKeyword);
         }
 
         static uint DivRoundUp(uint x, uint y) => (x + y - 1) / y;

--- a/package/Shaders/DeviceRadixSort.hlsl
+++ b/package/Shaders/DeviceRadixSort.hlsl
@@ -1,8 +1,9 @@
 /******************************************************************************
+ * DeviceRadixSort
  * Device Level 8-bit LSD Radix Sort using reduce then scan
  * 
  * SPDX-License-Identifier: MIT
- * Copyright Thomas Smith 2/13/2023
+ * Copyright Thomas Smith 5/17/2024
  * https://github.com/b0nes164/GPUSorting
  *  
  *  Permission is hereby granted, free of charge, to any person obtaining a copy
@@ -23,117 +24,20 @@
  *  OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE
  *  SOFTWARE.
  ******************************************************************************/
-//General macros 
-#define PART_SIZE       3840U       //size of a partition tile
+#include "SortCommon.hlsl"
 
 #define US_DIM          128U        //The number of threads in a Upsweep threadblock
 #define SCAN_DIM        128U        //The number of threads in a Scan threadblock
-#define DS_DIM          256U        //The number of threads in a Downsweep threadblock
 
-#define RADIX           256U        //Number of digit bins
-#define RADIX_MASK      255U        //Mask of digit bins
-#define RADIX_LOG       8U          //log2(RADIX)
+RWStructuredBuffer<uint> b_globalHist;  //buffer holding device level offsets for each binning pass
+RWStructuredBuffer<uint> b_passHist;    //buffer used to store reduced sums of partition tiles
 
-#define HALF_RADIX      128U        //For smaller waves where bit packing is necessary
-#define HALF_MASK       127U        // '' 
+groupshared uint g_us[RADIX * 2];   //Shared memory for upsweep
+groupshared uint g_scan[SCAN_DIM];  //Shared memory for the scan
 
-//For the downsweep kernels
-#define DS_KEYS_PER_THREAD  15U     //The number of keys per thread in a Downsweep Threadblock
-#define MAX_DS_SMEM         4096U   //shared memory for downsweep kernel
-
-cbuffer cbParallelSort : register(b0)
-{
-    uint e_numKeys;
-    uint e_radixShift;
-    uint e_threadBlocks;
-    uint padding0;
-};
-
-RWStructuredBuffer<uint> b_sort;            //buffer to be sorted
-RWStructuredBuffer<uint> b_alt;             //payload buffer
-RWStructuredBuffer<uint> b_sortPayload;     //double buffer
-RWStructuredBuffer<uint> b_altPayload;      //double buffer payload
-RWStructuredBuffer<uint> b_globalHist;      //buffer holding global device level offsets 
-                                            //for each digit during a binning pass
-RWStructuredBuffer<uint> b_passHist;        //buffer used to store device level offsets for 
-                                            //each partition tile for each digit during a binning pass
-
-groupshared uint g_us[RADIX * 2];           //Shared memory for upsweep kernel
-groupshared uint g_scan[SCAN_DIM];          //Shared memory for the scan kernel
-groupshared uint g_ds[MAX_DS_SMEM];         //Shared memory for the downsweep kernel
-
-inline uint getWaveIndex(uint gtid)
-{
-    return gtid / WaveGetLaneCount();
-}
-
-inline uint ExtractDigit(uint key)
-{
-    return key >> e_radixShift & RADIX_MASK;
-}
-
-inline uint ExtractPackedIndex(uint key)
-{
-    return key >> (e_radixShift + 1) & HALF_MASK;
-}
-
-inline uint ExtractPackedShift(uint key)
-{
-    return (key >> e_radixShift & 1) ? 16 : 0;
-}
-
-inline uint ExtractPackedValue(uint packed, uint key)
-{
-    return packed >> ExtractPackedShift(key) & 0xffff;
-}
-
-inline uint SubPartSizeWGE16()
-{
-    return DS_KEYS_PER_THREAD * WaveGetLaneCount();
-}
-
-inline uint SharedOffsetWGE16(uint gtid)
-{
-    return WaveGetLaneIndex() + getWaveIndex(gtid) * SubPartSizeWGE16();
-}
-
-inline uint DeviceOffsetWGE16(uint gtid, uint gid)
-{
-    return SharedOffsetWGE16(gtid) + gid * PART_SIZE;
-}
-
-inline uint SubPartSizeWLT16(uint _serialIterations)
-{
-    return DS_KEYS_PER_THREAD * WaveGetLaneCount() * _serialIterations;
-}
-
-inline uint SharedOffsetWLT16(uint gtid, uint _serialIterations)
-{
-    return WaveGetLaneIndex() +
-        (getWaveIndex(gtid) / _serialIterations * SubPartSizeWLT16(_serialIterations)) +
-        (getWaveIndex(gtid) % _serialIterations * WaveGetLaneCount());
-}
-
-inline uint DeviceOffsetWLT16(uint gtid, uint gid, uint _serialIterations)
-{
-    return SharedOffsetWLT16(gtid, _serialIterations) + gid * PART_SIZE;
-}
-
-inline uint GlobalHistOffset()
-{
-    return e_radixShift << 5;
-}
-
-inline uint WaveHistsSizeWGE16()
-{
-    return DS_DIM / WaveGetLaneCount() * RADIX;
-}
-
-inline uint WaveHistsSizeWLT16()
-{
-    return MAX_DS_SMEM;
-}
-
+//*****************************************************************************
+//INIT KERNEL
+//*****************************************************************************
 //Clear the global histogram, as we will be adding to it atomically
 [numthreads(1024, 1, 1)]
 void InitDeviceRadixSort(int3 id : SV_DispatchThreadID)
@@ -141,665 +45,487 @@ void InitDeviceRadixSort(int3 id : SV_DispatchThreadID)
     b_globalHist[id.x] = 0;
 }
 
+//*****************************************************************************
+//UPSWEEP KERNEL
+//*****************************************************************************
+//histogram, 64 threads to a histogram
+inline void HistogramDigitCounts(uint gtid, uint gid)
+{
+    const uint histOffset = gtid / 64 * RADIX;
+    const uint partitionEnd = gid == e_threadBlocks - 1 ?
+        e_numKeys : (gid + 1) * PART_SIZE;
+    for (uint i = gtid + gid * PART_SIZE; i < partitionEnd; i += US_DIM)
+    {
+#if defined(KEY_UINT)
+        InterlockedAdd(g_us[ExtractDigit(b_sort[i]) + histOffset], 1);
+#elif defined(KEY_INT)
+        InterlockedAdd(g_us[ExtractDigit(IntToUint(b_sort[i])) + histOffset], 1);
+#elif defined(KEY_FLOAT)
+        InterlockedAdd(g_us[ExtractDigit(FloatToUint(b_sort[i])) + histOffset], 1);
+#endif
+    }
+}
+
+//reduce and pass to tile histogram
+inline void ReduceWriteDigitCounts(uint gtid, uint gid)
+{
+    for (uint i = gtid; i < RADIX; i += US_DIM)
+    {
+        g_us[i] += g_us[i + RADIX];
+        b_passHist[i * e_threadBlocks + gid] = g_us[i];
+        g_us[i] += WavePrefixSum(g_us[i]);
+    }
+}
+
+//Exclusive scan over digit counts, then atomically add to global hist
+inline void GlobalHistExclusiveScanWGE16(uint gtid, uint waveSize)
+{
+    GroupMemoryBarrierWithGroupSync();
+        
+    if (gtid < (RADIX / waveSize))
+    {
+        g_us[(gtid + 1) * waveSize - 1] +=
+            WavePrefixSum(g_us[(gtid + 1) * waveSize - 1]);
+    }
+    GroupMemoryBarrierWithGroupSync();
+        
+    //atomically add to global histogram
+    const uint globalHistOffset = GlobalHistOffset();
+    const uint laneMask = waveSize - 1;
+    const uint circularLaneShift = WaveGetLaneIndex() + 1 & laneMask;
+    for (uint i = gtid; i < RADIX; i += US_DIM)
+    {
+        const uint index = circularLaneShift + (i & ~laneMask);
+        uint t = WaveGetLaneIndex() != laneMask ? g_us[i] : 0;
+        if (i >= waveSize)
+            t += WaveReadLaneAt(g_us[i - 1], 0);
+        InterlockedAdd(b_globalHist[index + globalHistOffset], t);
+    }
+}
+
+inline void GlobalHistExclusiveScanWLT16(uint gtid, uint waveSize)
+{
+    const uint globalHistOffset = GlobalHistOffset();
+    if (gtid < waveSize)
+    {
+        const uint circularLaneShift = WaveGetLaneIndex() + 1 &
+            waveSize - 1;
+        InterlockedAdd(b_globalHist[circularLaneShift + globalHistOffset],
+            circularLaneShift ? g_us[gtid] : 0);
+    }
+    GroupMemoryBarrierWithGroupSync();
+        
+    const uint laneLog = countbits(waveSize - 1);
+    uint offset = laneLog;
+    uint j = waveSize;
+    for (; j < (RADIX >> 1); j <<= laneLog)
+    {
+        if (gtid < (RADIX >> offset))
+        {
+            g_us[((gtid + 1) << offset) - 1] +=
+                WavePrefixSum(g_us[((gtid + 1) << offset) - 1]);
+        }
+        GroupMemoryBarrierWithGroupSync();
+            
+        for (uint i = gtid + j; i < RADIX; i += US_DIM)
+        {
+            if ((i & ((j << laneLog) - 1)) >= j)
+            {
+                if (i < (j << laneLog))
+                {
+                    InterlockedAdd(b_globalHist[i + globalHistOffset],
+                        WaveReadLaneAt(g_us[((i >> offset) << offset) - 1], 0) +
+                        ((i & (j - 1)) ? g_us[i - 1] : 0));
+                }
+                else
+                {
+                    if ((i + 1) & (j - 1))
+                    {
+                        g_us[i] +=
+                            WaveReadLaneAt(g_us[((i >> offset) << offset) - 1], 0);
+                    }
+                }
+            }
+        }
+        offset += laneLog;
+    }
+    GroupMemoryBarrierWithGroupSync();
+        
+    //If RADIX is not a power of lanecount
+    for (uint i = gtid + j; i < RADIX; i += US_DIM)
+    {
+        InterlockedAdd(b_globalHist[i + globalHistOffset],
+            WaveReadLaneAt(g_us[((i >> offset) << offset) - 1], 0) +
+            ((i & (j - 1)) ? g_us[i - 1] : 0));
+    }
+}
+
 [numthreads(US_DIM, 1, 1)]
 void Upsweep(uint3 gtid : SV_GroupThreadID, uint3 gid : SV_GroupID)
 {
+    //get the wave size
+    const uint waveSize = getWaveSize();
+    
     //clear shared memory
     const uint histsEnd = RADIX * 2;
     for (uint i = gtid.x; i < histsEnd; i += US_DIM)
         g_us[i] = 0;
     GroupMemoryBarrierWithGroupSync();
 
-    //histogram, 64 threads to a histogram
-    const uint histOffset = gtid.x / 64 * RADIX;
-    const uint partitionEnd = gid.x == e_threadBlocks - 1 ?
-        e_numKeys : (gid.x + 1) * PART_SIZE;
-    for (uint i = gtid.x + gid.x * PART_SIZE; i < partitionEnd; i += US_DIM)
-        InterlockedAdd(g_us[ExtractDigit(b_sort[i]) + histOffset], 1);
+    HistogramDigitCounts(gtid.x, gid.x);
     GroupMemoryBarrierWithGroupSync();
     
-    //reduce and pass to tile histogram
-    for (uint i = gtid.x; i < RADIX; i += US_DIM)
-    {
-        g_us[i] += g_us[i + RADIX];
-        b_passHist[i * e_threadBlocks + gid.x] = g_us[i];
-    }
+    ReduceWriteDigitCounts(gtid.x, gid.x);
     
-    //Larger 16 or greater can perform a more elegant scan because 16 * 16 = 256
-    if (WaveGetLaneCount() >= 16)
-    {
-        for (uint i = gtid.x; i < RADIX; i += US_DIM)
-            g_us[i] += WavePrefixSum(g_us[i]);
-        GroupMemoryBarrierWithGroupSync();
-        
-        if (gtid.x < (RADIX / WaveGetLaneCount()))
-        {
-            g_us[(gtid.x + 1) * WaveGetLaneCount() - 1] +=
-                WavePrefixSum(g_us[(gtid.x + 1) * WaveGetLaneCount() - 1]);
-        }
-        GroupMemoryBarrierWithGroupSync();
-        
-        //atomically add to global histogram
-        const uint globalHistOffset = GlobalHistOffset();
-        const uint laneMask = WaveGetLaneCount() - 1;
-        const uint circularLaneShift = WaveGetLaneIndex() + 1 & laneMask;
-        for (uint i = gtid.x; i < RADIX; i += US_DIM)
-        {
-            const uint index = circularLaneShift + (i & ~laneMask);
-            InterlockedAdd(b_globalHist[index + globalHistOffset],
-                (WaveGetLaneIndex() != laneMask ? g_us[i] : 0) +
-                (i >= WaveGetLaneCount() ? WaveReadLaneAt(g_us[i - 1], 0) : 0));
-        }
-    }
+    if (waveSize >= 16)
+        GlobalHistExclusiveScanWGE16(gtid.x, waveSize);
     
-    //Exclusive Brent-Kung with fused upsweep downsweep
-    if (WaveGetLaneCount() < 16)
+    if (waveSize < 16)
+        GlobalHistExclusiveScanWLT16(gtid.x, waveSize);
+}
+
+//*****************************************************************************
+//SCAN KERNEL
+//*****************************************************************************
+inline void ExclusiveThreadBlockScanFullWGE16(
+    uint gtid,
+    uint laneMask,
+    uint circularLaneShift,
+    uint partEnd,
+    uint deviceOffset,
+    uint waveSize,
+    inout uint reduction)
+{
+    for (uint i = gtid; i < partEnd; i += SCAN_DIM)
     {
-        const uint globalHistOffset = GlobalHistOffset();
-        for (uint i = gtid.x; i < RADIX; i += US_DIM)
-            g_us[i] += WavePrefixSum(g_us[i]);
-        
-        if (gtid.x < WaveGetLaneCount())
-        {
-            const uint circularLaneShift = WaveGetLaneIndex() + 1 &
-                WaveGetLaneCount() - 1;
-            InterlockedAdd(b_globalHist[circularLaneShift + globalHistOffset],
-                circularLaneShift ? g_us[gtid.x] : 0);
-        }
+        g_scan[gtid] = b_passHist[i + deviceOffset];
+        g_scan[gtid] += WavePrefixSum(g_scan[gtid]);
         GroupMemoryBarrierWithGroupSync();
-        
-        const uint laneLog = countbits(WaveGetLaneCount() - 1);
-        uint offset = laneLog;
-        uint j = WaveGetLaneCount();
-        for (; j < (RADIX >> 1); j <<= laneLog)
-        {
-            for (uint i = gtid.x; i < (RADIX >> offset); i += US_DIM)
-            {
-                g_us[((i + 1) << offset) - 1] +=
-                    WavePrefixSum(g_us[((i + 1) << offset) - 1]);
-            }
-            GroupMemoryBarrierWithGroupSync();
             
-            for (uint i = gtid.x + j; i < RADIX; i += US_DIM)
-            {
-                if ((i & ((j << laneLog) - 1)) >= j)
-                {
-                    if (i < (j << laneLog))
-                    {
-                        InterlockedAdd(b_globalHist[i + globalHistOffset],
-                            WaveReadLaneAt(g_us[((i >> offset) << offset) - 1], 0) +
-                            ((i & (j - 1)) ? g_us[i - 1] : 0));
-                    }
-                    else
-                    {
-                        if ((i + 1) & (j - 1))
-                        {
-                            g_us[i] +=
-                                WaveReadLaneAt(g_us[((i >> offset) << offset) - 1], 0);
-                        }
-                    }
-                }
-            }
-            offset += laneLog;
+        if (gtid < SCAN_DIM / waveSize)
+        {
+            g_scan[(gtid + 1) * waveSize - 1] +=
+                WavePrefixSum(g_scan[(gtid + 1) * waveSize - 1]);
         }
         GroupMemoryBarrierWithGroupSync();
         
-        for (uint i = gtid.x + j; i < RADIX; i += US_DIM)
-        {
-            InterlockedAdd(b_globalHist[i + globalHistOffset],
-                WaveReadLaneAt(g_us[((i >> offset) << offset) - 1], 0) +
-                ((i & (j - 1)) ? g_us[i - 1] : 0));
-        }
+        uint t = (WaveGetLaneIndex() != laneMask ? g_scan[gtid] : 0) + reduction;
+        if (gtid >= waveSize)
+            t += WaveReadLaneAt(g_scan[gtid - 1], 0);
+        b_passHist[circularLaneShift + (i & ~laneMask) + deviceOffset] = t;
+
+        reduction += g_scan[SCAN_DIM - 1];
+        GroupMemoryBarrierWithGroupSync();
     }
 }
 
-//Scan along the spine of the upsweep
-[numthreads(SCAN_DIM, 1, 1)]
-void Scan(uint3 gtid : SV_GroupThreadID, uint3 gid : SV_GroupID)
+inline void ExclusiveThreadBlockScanPartialWGE16(
+    uint gtid,
+    uint laneMask,
+    uint circularLaneShift,
+    uint partEnd,
+    uint deviceOffset,
+    uint waveSize,
+    uint reduction)
 {
-    if (WaveGetLaneCount() >= 16)
+    uint i = gtid + partEnd;
+    if (i < e_threadBlocks)
+        g_scan[gtid] = b_passHist[deviceOffset + i];
+    g_scan[gtid] += WavePrefixSum(g_scan[gtid]);
+    GroupMemoryBarrierWithGroupSync();
+            
+    if (gtid < SCAN_DIM / waveSize)
     {
-        uint aggregate = 0;
-        const uint laneMask = WaveGetLaneCount() - 1;
-        const uint circularLaneShift = WaveGetLaneIndex() + 1 & laneMask;
-        const uint partionsEnd = e_threadBlocks / SCAN_DIM * SCAN_DIM;
-        const uint offset = gid.x * e_threadBlocks;
-        uint i = gtid.x;
-        for (; i < partionsEnd; i += SCAN_DIM)
-        {
-            g_scan[gtid.x] = b_passHist[i + offset];
-            g_scan[gtid.x] += WavePrefixSum(g_scan[gtid.x]);
-            GroupMemoryBarrierWithGroupSync();
-            
-            if (gtid.x < SCAN_DIM / WaveGetLaneCount())
-            {
-                g_scan[(gtid.x + 1) * WaveGetLaneCount() - 1] +=
-                    WavePrefixSum(g_scan[(gtid.x + 1) * WaveGetLaneCount() - 1]);
-            }
-            GroupMemoryBarrierWithGroupSync();
-            
-            b_passHist[circularLaneShift + (i & ~laneMask) + offset] =
-                (WaveGetLaneIndex() != laneMask ? g_scan[gtid.x] : 0) +
-                (gtid.x >= WaveGetLaneCount() ?
-                WaveReadLaneAt(g_scan[gtid.x - 1], 0) : 0) +
-                aggregate;
-
-            aggregate += g_scan[SCAN_DIM - 1];
-            GroupMemoryBarrierWithGroupSync();
-        }
-        
-        //partial
-        if (i < e_threadBlocks)
-            g_scan[gtid.x] = b_passHist[offset + i];
-        g_scan[gtid.x] += WavePrefixSum(g_scan[gtid.x]);
-        GroupMemoryBarrierWithGroupSync();
-            
-        if (gtid.x < SCAN_DIM / WaveGetLaneCount())
-        {
-            g_scan[(gtid.x + 1) * WaveGetLaneCount() - 1] +=
-                WavePrefixSum(g_scan[(gtid.x + 1) * WaveGetLaneCount() - 1]);
-        }
-        GroupMemoryBarrierWithGroupSync();
-        
-        const uint index = circularLaneShift + (i & ~laneMask);
-        if (index < e_threadBlocks)
-        {
-            b_passHist[index + offset] = (WaveGetLaneIndex() != laneMask ? g_scan[gtid.x] : 0) +
-                (gtid.x >= WaveGetLaneCount() ? g_scan[(gtid.x & ~laneMask) - 1] : 0) + aggregate;
-        }
+        g_scan[(gtid + 1) * waveSize - 1] +=
+            WavePrefixSum(g_scan[(gtid + 1) * waveSize - 1]);
     }
-
-    if (WaveGetLaneCount() < 16)
+    GroupMemoryBarrierWithGroupSync();
+        
+    const uint index = circularLaneShift + (i & ~laneMask);
+    if (index < e_threadBlocks)
     {
-        uint aggregate = 0;
-        const uint partitions = e_threadBlocks / SCAN_DIM;
-        const uint deviceOffset = gid.x * e_threadBlocks;
-        const uint laneLog = countbits(WaveGetLaneCount() - 1);
-        const uint circularLaneShift = WaveGetLaneIndex() + 1 &
-                    WaveGetLaneCount() - 1;
-        
-        uint k = 0;
-        for (; k < partitions; ++k)
-        {
-            g_scan[gtid.x] = b_passHist[gtid.x + k * SCAN_DIM + deviceOffset];
-            g_scan[gtid.x] += WavePrefixSum(g_scan[gtid.x]);
-            
-            if (gtid.x < WaveGetLaneCount())
-            {
-                b_passHist[circularLaneShift + k * SCAN_DIM + deviceOffset] =
-                    (circularLaneShift ? g_scan[gtid.x] : 0) + aggregate;
-            }
-            GroupMemoryBarrierWithGroupSync();
-            
-            uint offset = laneLog;
-            uint j = WaveGetLaneCount();
-            for (; j < (SCAN_DIM >> 1); j <<= laneLog)
-            {
-                for (uint i = gtid.x; i < (SCAN_DIM >> offset); i += SCAN_DIM)
-                {
-                    g_scan[((i + 1) << offset) - 1] +=
-                        WavePrefixSum(g_scan[((i + 1) << offset) - 1]);
-                }
-                GroupMemoryBarrierWithGroupSync();
-            
-                if ((gtid.x & ((j << laneLog) - 1)) >= j)
-                {
-                    if (gtid.x < (j << laneLog))
-                    {
-                        b_passHist[gtid.x + k * SCAN_DIM + deviceOffset] =
-                            WaveReadLaneAt(g_scan[((gtid.x >> offset) << offset) - 1], 0) +
-                            ((gtid.x & (j - 1)) ? g_scan[gtid.x - 1] : 0) + aggregate;
-                    }
-                    else
-                    {
-                        if ((gtid.x + 1) & (j - 1))
-                        {
-                            g_scan[gtid.x] +=
-                                WaveReadLaneAt(g_scan[((gtid.x >> offset) << offset) - 1], 0);
-                        }
-                    }
-                }
-                offset += laneLog;
-            }
-            GroupMemoryBarrierWithGroupSync();
-        
-            for (uint i = gtid.x + j; i < SCAN_DIM; i += SCAN_DIM)
-            {
-                b_passHist[i + k * SCAN_DIM + deviceOffset] =
-                    WaveReadLaneAt(g_scan[((i >> offset) << offset) - 1], 0) +
-                    ((i & (j - 1)) ? g_scan[i - 1] : 0) + aggregate;
-            }
-            
-            aggregate += WaveReadLaneAt(g_scan[SCAN_DIM - 1], 0) +
-                WaveReadLaneAt(g_scan[(((SCAN_DIM - 1) >> offset) << offset) - 1], 0);
-            GroupMemoryBarrierWithGroupSync();
-        }
-        
-        //partial
-        const uint finalPartSize = e_threadBlocks - k * SCAN_DIM;
-        if (gtid.x < finalPartSize)
-        {
-            g_scan[gtid.x] = b_passHist[gtid.x + k * SCAN_DIM + deviceOffset];
-            g_scan[gtid.x] += WavePrefixSum(g_scan[gtid.x]);
-        }
-        
-        if (gtid.x < WaveGetLaneCount() && circularLaneShift < finalPartSize)
+        uint t = (WaveGetLaneIndex() != laneMask ? g_scan[gtid] : 0) + reduction;
+        if (gtid >= waveSize)
+            t += g_scan[(gtid & ~laneMask) - 1];
+        b_passHist[index + deviceOffset] = t;
+    }
+}
+
+inline void ExclusiveThreadBlockScanWGE16(uint gtid, uint gid, uint waveSize)
+{
+    uint reduction = 0;
+    const uint laneMask = waveSize - 1;
+    const uint circularLaneShift = WaveGetLaneIndex() + 1 & laneMask;
+    const uint partionsEnd = e_threadBlocks / SCAN_DIM * SCAN_DIM;
+    const uint deviceOffset = gid * e_threadBlocks;
+    
+    ExclusiveThreadBlockScanFullWGE16(
+        gtid,
+        laneMask,
+        circularLaneShift,
+        partionsEnd,
+        deviceOffset,
+        waveSize,
+        reduction);
+
+    ExclusiveThreadBlockScanPartialWGE16(
+        gtid,
+        laneMask,
+        circularLaneShift,
+        partionsEnd,
+        deviceOffset,
+        waveSize,
+        reduction);
+}
+
+inline void ExclusiveThreadBlockScanFullWLT16(
+    uint gtid,
+    uint partitions,
+    uint deviceOffset,
+    uint laneLog,
+    uint circularLaneShift,
+    uint waveSize,
+    inout uint reduction)
+{
+    for (uint k = 0; k < partitions; ++k)
+    {
+        g_scan[gtid] = b_passHist[gtid + k * SCAN_DIM + deviceOffset];
+        g_scan[gtid] += WavePrefixSum(g_scan[gtid]);
+        GroupMemoryBarrierWithGroupSync();
+        if (gtid < waveSize)
         {
             b_passHist[circularLaneShift + k * SCAN_DIM + deviceOffset] =
-                    (circularLaneShift ? g_scan[gtid.x] : 0) + aggregate;
+                (circularLaneShift ? g_scan[gtid] : 0) + reduction;
         }
-        GroupMemoryBarrierWithGroupSync();
-        
+            
         uint offset = laneLog;
-        for (uint j = WaveGetLaneCount(); j < finalPartSize; j <<= laneLog)
+        uint j = waveSize;
+        for (; j < (SCAN_DIM >> 1); j <<= laneLog)
         {
-            for (uint i = gtid.x; i < (finalPartSize >> offset); i += SCAN_DIM)
+            if (gtid < (SCAN_DIM >> offset))
             {
-                g_scan[((i + 1) << offset) - 1] +=
-                    WavePrefixSum(g_scan[((i + 1) << offset) - 1]);
+                g_scan[((gtid + 1) << offset) - 1] +=
+                    WavePrefixSum(g_scan[((gtid + 1) << offset) - 1]);
             }
             GroupMemoryBarrierWithGroupSync();
             
-            if ((gtid.x & ((j << laneLog) - 1)) >= j && gtid.x < finalPartSize)
+            if ((gtid & ((j << laneLog) - 1)) >= j)
             {
-                if (gtid.x < (j << laneLog))
+                if (gtid < (j << laneLog))
                 {
-                    b_passHist[gtid.x + k * SCAN_DIM + deviceOffset] =
-                        WaveReadLaneAt(g_scan[((gtid.x >> offset) << offset) - 1], 0) +
-                        ((gtid.x & (j - 1)) ? g_scan[gtid.x - 1] : 0) + aggregate;
+                    b_passHist[gtid + k * SCAN_DIM + deviceOffset] =
+                        WaveReadLaneAt(g_scan[((gtid >> offset) << offset) - 1], 0) +
+                        ((gtid & (j - 1)) ? g_scan[gtid - 1] : 0) + reduction;
                 }
                 else
                 {
-                    if ((gtid.x + 1) & (j - 1))
+                    if ((gtid + 1) & (j - 1))
                     {
-                        g_scan[gtid.x] +=
-                            WaveReadLaneAt(g_scan[((gtid.x >> offset) << offset) - 1], 0);
+                        g_scan[gtid] +=
+                            WaveReadLaneAt(g_scan[((gtid >> offset) << offset) - 1], 0);
                     }
                 }
             }
             offset += laneLog;
         }
+        GroupMemoryBarrierWithGroupSync();
+        
+        //If SCAN_DIM is not a power of lanecount
+        for (uint i = gtid + j; i < SCAN_DIM; i += SCAN_DIM)
+        {
+            b_passHist[i + k * SCAN_DIM + deviceOffset] =
+                WaveReadLaneAt(g_scan[((i >> offset) << offset) - 1], 0) +
+                ((i & (j - 1)) ? g_scan[i - 1] : 0) + reduction;
+        }
+            
+        reduction += WaveReadLaneAt(g_scan[SCAN_DIM - 1], 0) +
+            WaveReadLaneAt(g_scan[(((SCAN_DIM - 1) >> offset) << offset) - 1], 0);
+        GroupMemoryBarrierWithGroupSync();
     }
 }
 
-[numthreads(DS_DIM, 1, 1)]
+inline void ExclusiveThreadBlockScanParitalWLT16(
+    uint gtid,
+    uint partitions,
+    uint deviceOffset,
+    uint laneLog,
+    uint circularLaneShift,
+    uint waveSize,
+    uint reduction)
+{
+    const uint finalPartSize = e_threadBlocks - partitions * SCAN_DIM;
+    if (gtid < finalPartSize)
+    {
+        g_scan[gtid] = b_passHist[gtid + partitions * SCAN_DIM + deviceOffset];
+        g_scan[gtid] += WavePrefixSum(g_scan[gtid]);
+    }
+    GroupMemoryBarrierWithGroupSync();
+    if (gtid < waveSize && circularLaneShift < finalPartSize)
+    {
+        b_passHist[circularLaneShift + partitions * SCAN_DIM + deviceOffset] =
+            (circularLaneShift ? g_scan[gtid] : 0) + reduction;
+    }
+        
+    uint offset = laneLog;
+    for (uint j = waveSize; j < finalPartSize; j <<= laneLog)
+    {
+        if (gtid < (finalPartSize >> offset))
+        {
+            g_scan[((gtid + 1) << offset) - 1] +=
+                WavePrefixSum(g_scan[((gtid + 1) << offset) - 1]);
+        }
+        GroupMemoryBarrierWithGroupSync();
+            
+        if ((gtid & ((j << laneLog) - 1)) >= j && gtid < finalPartSize)
+        {
+            if (gtid < (j << laneLog))
+            {
+                b_passHist[gtid + partitions * SCAN_DIM + deviceOffset] =
+                    WaveReadLaneAt(g_scan[((gtid >> offset) << offset) - 1], 0) +
+                    ((gtid & (j - 1)) ? g_scan[gtid - 1] : 0) + reduction;
+            }
+            else
+            {
+                if ((gtid + 1) & (j - 1))
+                {
+                    g_scan[gtid] +=
+                        WaveReadLaneAt(g_scan[((gtid >> offset) << offset) - 1], 0);
+                }
+            }
+        }
+        offset += laneLog;
+    }
+}
+
+inline void ExclusiveThreadBlockScanWLT16(uint gtid, uint gid, uint waveSize)
+{
+    uint reduction = 0;
+    const uint partitions = e_threadBlocks / SCAN_DIM;
+    const uint deviceOffset = gid * e_threadBlocks;
+    const uint laneLog = countbits(waveSize - 1);
+    const uint circularLaneShift = WaveGetLaneIndex() + 1 & waveSize - 1;
+    
+    ExclusiveThreadBlockScanFullWLT16(
+        gtid,
+        partitions,
+        deviceOffset,
+        laneLog,
+        circularLaneShift,
+        waveSize,
+        reduction);
+    
+    ExclusiveThreadBlockScanParitalWLT16(
+        gtid,
+        partitions,
+        deviceOffset,
+        laneLog,
+        circularLaneShift,
+        waveSize,
+        reduction);
+}
+
+//Scan does not need flattening of gids
+[numthreads(SCAN_DIM, 1, 1)]
+void Scan(uint3 gtid : SV_GroupThreadID, uint3 gid : SV_GroupID)
+{
+    const uint waveSize = getWaveSize();
+    if (waveSize >= 16)
+        ExclusiveThreadBlockScanWGE16(gtid.x, gid.x, waveSize);
+
+    if (waveSize < 16)
+        ExclusiveThreadBlockScanWLT16(gtid.x, gid.x, waveSize);
+}
+
+//*****************************************************************************
+//DOWNSWEEP KERNEL
+//*****************************************************************************
+inline void LoadThreadBlockReductions(uint gtid, uint gid, uint exclusiveHistReduction)
+{
+    if (gtid < RADIX)
+    {
+        g_d[gtid + PART_SIZE] = b_globalHist[gtid + GlobalHistOffset()] +
+            b_passHist[gtid * e_threadBlocks + gid] - exclusiveHistReduction;
+    }
+}
+
+[numthreads(D_DIM, 1, 1)]
 void Downsweep(uint3 gtid : SV_GroupThreadID, uint3 gid : SV_GroupID)
 {
+    KeyStruct keys;
+    OffsetStruct offsets;
+    const uint waveSize = getWaveSize();
+    
+    ClearWaveHists(gtid.x, waveSize);
+    GroupMemoryBarrierWithGroupSync();
+    
     if (gid.x < e_threadBlocks - 1)
     {
-        uint keys[DS_KEYS_PER_THREAD];
-        uint offsets[DS_KEYS_PER_THREAD];
+        if (waveSize >= 16)
+            keys = LoadKeysWGE16(gtid.x, waveSize, gid.x);
         
-        if (WaveGetLaneCount() >= 16)
-        {
-            //Load keys into registers
-            [unroll]
-            for (uint i = 0, t = DeviceOffsetWGE16(gtid.x, gid.x);
-                 i < DS_KEYS_PER_THREAD;
-                 ++i, t += WaveGetLaneCount())
-            {
-                keys[i] = b_sort[t];
-            }
-            
-            //Clear histogram memory
-            for (uint i = gtid.x; i < WaveHistsSizeWGE16(); i += DS_DIM)
-                g_ds[i] = 0;
-            GroupMemoryBarrierWithGroupSync();
-
-            //Warp Level Multisplit
-            const uint waveParts = (WaveGetLaneCount() + 31) / 32;
-            [unroll]
-            for (uint i = 0; i < DS_KEYS_PER_THREAD; ++i)
-            {
-                uint4 waveFlags = (WaveGetLaneCount() & 31) ?
-                    (1U << WaveGetLaneCount()) - 1 : 0xffffffff;
-
-                [unroll]
-                for (uint k = 0; k < RADIX_LOG; ++k)
-                {
-                    const bool t = keys[i] >> (k + e_radixShift) & 1;
-                    const uint4 ballot = WaveActiveBallot(t);
-                    for (uint wavePart = 0; wavePart < waveParts; ++wavePart)
-                        waveFlags[wavePart] &= (t ? 0 : 0xffffffff) ^ ballot[wavePart];
-                }
-                    
-                uint bits = 0;
-                for (uint wavePart = 0; wavePart < waveParts; ++wavePart)
-                {
-                    if (WaveGetLaneIndex() >= wavePart * 32)
-                    {
-                        const uint ltMask = WaveGetLaneIndex() >= (wavePart + 1) * 32 ?
-                            0xffffffff : (1U << (WaveGetLaneIndex() & 31)) - 1;
-                        bits += countbits(waveFlags[wavePart] & ltMask);
-                    }
-                }
-                    
-                const uint index = ExtractDigit(keys[i]) + (getWaveIndex(gtid.x) * RADIX);
-                offsets[i] = g_ds[index] + bits;
-                    
-                GroupMemoryBarrierWithGroupSync();
-                if (bits == 0)
-                {
-                    for (uint wavePart = 0; wavePart < waveParts; ++wavePart)
-                        g_ds[index] += countbits(waveFlags[wavePart]);
-                }
-                GroupMemoryBarrierWithGroupSync();
-            }
-            
-            //inclusive/exclusive prefix sum up the histograms
-            //followed by exclusive prefix sum across the reductions
-            uint reduction = g_ds[gtid.x];
-            for (uint i = gtid.x + RADIX; i < WaveHistsSizeWGE16(); i += RADIX)
-            {
-                reduction += g_ds[i];
-                g_ds[i] = reduction - g_ds[i];
-            }
-            
-            reduction += WavePrefixSum(reduction);
-            GroupMemoryBarrierWithGroupSync();
-
-            const uint laneMask = WaveGetLaneCount() - 1;
-            g_ds[((WaveGetLaneIndex() + 1) & laneMask) + (gtid.x & ~laneMask)] = reduction;
-            GroupMemoryBarrierWithGroupSync();
-                
-            if (gtid.x < RADIX / WaveGetLaneCount())
-            {
-                g_ds[gtid.x * WaveGetLaneCount()] =
-                    WavePrefixSum(g_ds[gtid.x * WaveGetLaneCount()]);
-            }
-            GroupMemoryBarrierWithGroupSync();
-                
-            if (WaveGetLaneIndex())
-                g_ds[gtid.x] += WaveReadLaneAt(g_ds[gtid.x - 1], 1);
-            GroupMemoryBarrierWithGroupSync();
-        
-            //Update offsets
-            if (gtid.x >= WaveGetLaneCount())
-            {
-                const uint t = getWaveIndex(gtid.x) * RADIX;
-                [unroll]
-                for (uint i = 0; i < DS_KEYS_PER_THREAD; ++i)
-                {
-                    const uint t2 = ExtractDigit(keys[i]);
-                    offsets[i] += g_ds[t2 + t] + g_ds[t2];
-                }
-            }
-            else
-            {
-                [unroll]
-                for (uint i = 0; i < DS_KEYS_PER_THREAD; ++i)
-                    offsets[i] += g_ds[ExtractDigit(keys[i])];
-            }
-            
-            //take advantage of barrier
-            const uint exclusiveWaveReduction = g_ds[gtid.x];
-            GroupMemoryBarrierWithGroupSync();
-            
-            //scatter keys into shared memory
-            for (uint i = 0; i < DS_KEYS_PER_THREAD; ++i)
-                g_ds[offsets[i]] = keys[i];
-        
-            g_ds[gtid.x + PART_SIZE] = b_globalHist[gtid.x + GlobalHistOffset()] +
-                    b_passHist[gtid.x * e_threadBlocks + gid.x] - exclusiveWaveReduction;
-            GroupMemoryBarrierWithGroupSync();
-            
-            [unroll]
-            for (uint i = 0, t = SharedOffsetWGE16(gtid.x);
-                 i < DS_KEYS_PER_THREAD;
-                 ++i, t += WaveGetLaneCount())
-            {
-                keys[i] = g_ds[ExtractDigit(g_ds[t]) + PART_SIZE] + t;
-                b_alt[keys[i]] = g_ds[t];
-            }
-            GroupMemoryBarrierWithGroupSync();
-                
-            [unroll]
-            for (uint i = 0, t = DeviceOffsetWGE16(gtid.x, gid.x);
-                 i < DS_KEYS_PER_THREAD; 
-                 ++i, t += WaveGetLaneCount())
-            {
-                g_ds[offsets[i]] = b_sortPayload[t];
-            }
-            GroupMemoryBarrierWithGroupSync();
-            
-            [unroll]
-            for (uint i = 0, t = SharedOffsetWGE16(gtid.x);
-                 i < DS_KEYS_PER_THREAD;
-                 ++i, t += WaveGetLaneCount())
-            {
-                b_altPayload[keys[i]] = g_ds[t];
-            }
-        }
-        
-        if (WaveGetLaneCount() < 16)
-        {
-            const uint serialIterations = (DS_DIM / WaveGetLaneCount() + 31) / 32;
-            
-            //Load keys into registers
-            [unroll]
-            for (uint i = 0, t = DeviceOffsetWLT16(gtid.x, gid.x, serialIterations);
-                 i < DS_KEYS_PER_THREAD;
-                 ++i, t += WaveGetLaneCount() * serialIterations)
-            {
-                keys[i] = b_sort[t];
-            }
-                
-            //clear shared memory
-            for (uint i = gtid.x; i < WaveHistsSizeWLT16(); i += DS_DIM)
-                g_ds[i] = 0;
-            GroupMemoryBarrierWithGroupSync();
-            
-            const uint ltMask = (1U << WaveGetLaneIndex()) - 1;
-            [unroll]
-            for (uint i = 0; i < DS_KEYS_PER_THREAD; ++i)
-            {
-                uint waveFlag = (1U << WaveGetLaneCount()) - 1; //for full agnostic add ternary and uint4
-                
-                [unroll]
-                for (uint k = 0; k < RADIX_LOG; ++k)
-                {
-                    const bool t = keys[i] >> (k + e_radixShift) & 1;
-                    waveFlag &= (t ? 0 : 0xffffffff) ^ (uint) WaveActiveBallot(t);
-                }
-                
-                uint bits = countbits(waveFlag & ltMask);
-                const uint index = ExtractPackedIndex(keys[i]) +
-                    (getWaveIndex(gtid.x) / serialIterations * HALF_RADIX);
-                    
-                for (uint k = 0; k < serialIterations; ++k)
-                {
-                    if (getWaveIndex(gtid.x) % serialIterations == k)
-                        offsets[i] = ExtractPackedValue(g_ds[index], keys[i]) + bits;
-                    
-                    GroupMemoryBarrierWithGroupSync();
-                    if (getWaveIndex(gtid.x) % serialIterations == k && bits == 0)
-                    {
-                        InterlockedAdd(g_ds[index],
-                            countbits(waveFlag) << ExtractPackedShift(keys[i]));
-                    }
-                    GroupMemoryBarrierWithGroupSync();
-                }
-            }
-            
-            //inclusive/exclusive prefix sum up the histograms,
-            //use a blelloch scan for in place exclusive
-            uint reduction;
-            if (gtid.x < HALF_RADIX)
-            {
-                reduction = g_ds[gtid.x];
-                for (uint i = gtid.x + HALF_RADIX; i < WaveHistsSizeWLT16(); i += HALF_RADIX)
-                {
-                    reduction += g_ds[i];
-                    g_ds[i] = reduction - g_ds[i];
-                }
-                g_ds[gtid.x] = reduction + (reduction << 16);
-            }
-                
-            uint shift = 1;
-            for (uint j = RADIX >> 2; j > 0; j >>= 1)
-            {
-                GroupMemoryBarrierWithGroupSync();
-                for (uint i = gtid.x; i < j; i += DS_DIM)
-                {
-                    g_ds[((((i << 1) + 2) << shift) - 1) >> 1] +=
-                            g_ds[((((i << 1) + 1) << shift) - 1) >> 1] & 0xffff0000;
-                }
-                shift++;
-            }
-            GroupMemoryBarrierWithGroupSync();
-                
-            if (gtid.x == 0)
-                g_ds[HALF_RADIX - 1] &= 0xffff;
-                
-            for (uint j = 1; j < RADIX >> 1; j <<= 1)
-            {
-                --shift;
-                GroupMemoryBarrierWithGroupSync();
-                for (uint i = gtid.x; i < j; i += DS_DIM)
-                {
-                    const uint t = ((((i << 1) + 1) << shift) - 1) >> 1;
-                    const uint t2 = ((((i << 1) + 2) << shift) - 1) >> 1;
-                    const uint t3 = g_ds[t];
-                    g_ds[t] = (g_ds[t] & 0xffff) | (g_ds[t2] & 0xffff0000);
-                    g_ds[t2] += t3 & 0xffff0000;
-                }
-            }
-
-            GroupMemoryBarrierWithGroupSync();
-            if (gtid.x < HALF_RADIX)
-            {
-                const uint t = g_ds[gtid.x];
-                g_ds[gtid.x] = (t >> 16) + (t << 16) + (t & 0xffff0000);
-            }
-            GroupMemoryBarrierWithGroupSync();
-            
-            //Update offsets
-            if (gtid.x >= WaveGetLaneCount() * serialIterations)
-            {
-                const uint t = getWaveIndex(gtid.x) / serialIterations * HALF_RADIX;
-                [unroll]
-                for (uint i = 0; i < DS_KEYS_PER_THREAD; ++i)
-                {
-                    const uint t2 = ExtractPackedIndex(keys[i]);
-                    offsets[i] += ExtractPackedValue(g_ds[t2 + t] + g_ds[t2], keys[i]);
-                }
-            }
-            else
-            {
-                [unroll]
-                for (uint i = 0; i < DS_KEYS_PER_THREAD; ++i)
-                    offsets[i] += ExtractPackedValue(g_ds[ExtractPackedIndex(keys[i])], keys[i]);
-            }
-            
-            const uint exclusiveWaveReduction = g_ds[gtid.x >> 1] >> ((gtid.x & 1) ? 16 : 0) & 0xffff;
-            GroupMemoryBarrierWithGroupSync();
-            
-            //scatter keys into shared memory
-            for (uint i = 0; i < DS_KEYS_PER_THREAD; ++i)
-                g_ds[offsets[i]] = keys[i];
-        
-            g_ds[gtid.x + PART_SIZE] = b_globalHist[gtid.x + GlobalHistOffset()] +
-                    b_passHist[gtid.x * e_threadBlocks + gid.x] - exclusiveWaveReduction;
-            GroupMemoryBarrierWithGroupSync();
-        
-            //scatter runs of keys into device memory, 
-            //store the scatter location in the key register to reuse for the payload
-            [unroll]
-            for (uint i = 0, t = SharedOffsetWLT16(gtid.x, serialIterations);
-                 i < DS_KEYS_PER_THREAD;
-                 ++i, t += WaveGetLaneCount() * serialIterations)
-            {
-                keys[i] = g_ds[ExtractDigit(g_ds[t]) + PART_SIZE] + t;
-                b_alt[keys[i]] = g_ds[t];
-            }
-            GroupMemoryBarrierWithGroupSync();
-                
-            [unroll]
-            for (uint i = 0, t = DeviceOffsetWLT16(gtid.x, gid.x, serialIterations);
-                 i < DS_KEYS_PER_THREAD; 
-                 ++i, t += WaveGetLaneCount() * serialIterations)
-            {
-                g_ds[offsets[i]] = b_sortPayload[t];
-            }
-            GroupMemoryBarrierWithGroupSync();
-            
-            [unroll]
-            for (uint i = 0, t = SharedOffsetWLT16(gtid.x, serialIterations);
-                 i < DS_KEYS_PER_THREAD;
-                 ++i, t += WaveGetLaneCount() * serialIterations)
-            {
-                b_altPayload[keys[i]] = g_ds[t];
-            }
-        }
+        if (waveSize < 16)
+            keys = LoadKeysWLT16(gtid.x, waveSize, gid.x, SerialIterations(waveSize));
     }
-    
-    //perform the sort on the final partition slightly differently 
-    //to handle input sizes not perfect multiples of the partition
+        
     if (gid.x == e_threadBlocks - 1)
     {
-        //load the global and pass histogram values into shared memory
+        if (waveSize >= 16)
+            keys = LoadKeysPartialWGE16(gtid.x, waveSize, gid.x);
+        
+        if (waveSize < 16)
+            keys = LoadKeysPartialWLT16(gtid.x, waveSize, gid.x, SerialIterations(waveSize));
+    }
+    
+    uint exclusiveHistReduction;
+    
+    if (waveSize >= 16)
+    {
+        offsets = RankKeysWGE16(waveSize, getWaveIndex(gtid.x, waveSize) * RADIX, keys);
+        GroupMemoryBarrierWithGroupSync();
+        
+        uint histReduction;
         if (gtid.x < RADIX)
         {
-            g_ds[gtid.x] = b_globalHist[gtid.x + GlobalHistOffset()] +
-                b_passHist[gtid.x * e_threadBlocks + gid.x];
+            histReduction = WaveHistInclusiveScanCircularShiftWGE16(gtid.x, waveSize);
+            histReduction += WavePrefixSum(histReduction); //take advantage of barrier to begin scan
         }
         GroupMemoryBarrierWithGroupSync();
         
-        const uint waveParts = (WaveGetLaneCount() + 31) / 32;
-        const uint partEnd = (e_numKeys + DS_DIM - 1) / DS_DIM * DS_DIM;
-        for (uint i = gtid.x + gid.x * PART_SIZE; i < partEnd; i += DS_DIM)
-        {
-            uint key;
-            if (i < e_numKeys)
-            {
-                key = b_sort[i];
-            }
+        WaveHistReductionExclusiveScanWGE16(gtid.x, waveSize, histReduction);
+        GroupMemoryBarrierWithGroupSync();
             
-            uint4 waveFlags = (WaveGetLaneCount() & 31) ?
-                (1U << WaveGetLaneCount()) - 1 : 0xffffffff;
-            uint offset;
-            uint bits = 0;
-            if (i < e_numKeys)
-            {
-                [unroll]
-                for (uint k = 0; k < RADIX_LOG; ++k)
-                {
-                    const bool t = key >> (k + e_radixShift) & 1;
-                    const uint4 ballot = WaveActiveBallot(t);
-                    for (uint wavePart = 0; wavePart < waveParts; ++wavePart)
-                        waveFlags[wavePart] &= (t ? 0 : 0xffffffff) ^ ballot[wavePart];
-                }
-            
-                for (uint wavePart = 0; wavePart < waveParts; ++wavePart)
-                {
-                    if (WaveGetLaneIndex() >= wavePart * 32)
-                    {
-                        const uint ltMask = WaveGetLaneIndex() >= (wavePart + 1) * 32 ?
-                            0xffffffff : (1U << (WaveGetLaneIndex() & 31)) - 1;
-                        bits += countbits(waveFlags[wavePart] & ltMask);
-                    }
-                }
-            }
-            
-            for (uint k = 0; k < DS_DIM / WaveGetLaneCount(); ++k)
-            {
-                if (getWaveIndex(gtid.x) == k && i < e_numKeys)
-                    offset = g_ds[ExtractDigit(key)] + bits;
-                GroupMemoryBarrierWithGroupSync();
-                
-                if (getWaveIndex(gtid.x) == k && i < e_numKeys && bits == 0)
-                {
-                    for (uint wavePart = 0; wavePart < waveParts; ++wavePart)
-                        g_ds[ExtractDigit(key)] += countbits(waveFlags[wavePart]);
-                }
-                GroupMemoryBarrierWithGroupSync();
-            }
-
-            if (i < e_numKeys)
-            {
-                b_alt[offset] = key;
-                b_altPayload[offset] = b_sortPayload[i];
-            }
-        }
+        UpdateOffsetsWGE16(gtid.x, waveSize, offsets, keys);
+        if (gtid.x < RADIX)
+            exclusiveHistReduction = g_d[gtid.x]; //take advantage of barrier to grab value
+        GroupMemoryBarrierWithGroupSync();
     }
+    
+    if (waveSize < 16)
+    {
+        offsets = RankKeysWLT16(waveSize, getWaveIndex(gtid.x, waveSize), keys, SerialIterations(waveSize));
+            
+        if (gtid.x < HALF_RADIX)
+        {
+            uint histReduction = WaveHistInclusiveScanCircularShiftWLT16(gtid.x);
+            g_d[gtid.x] = histReduction + (histReduction << 16); //take advantage of barrier to begin scan
+        }
+            
+        WaveHistReductionExclusiveScanWLT16(gtid.x);
+        GroupMemoryBarrierWithGroupSync();
+            
+        UpdateOffsetsWLT16(gtid.x, waveSize, SerialIterations(waveSize), offsets, keys);
+        if (gtid.x < RADIX) //take advantage of barrier to grab value
+            exclusiveHistReduction = g_d[gtid.x >> 1] >> ((gtid.x & 1) ? 16 : 0) & 0xffff;
+        GroupMemoryBarrierWithGroupSync();
+    }
+    
+    ScatterKeysShared(offsets, keys);
+    LoadThreadBlockReductions(gtid.x, gid.x, exclusiveHistReduction);
+    GroupMemoryBarrierWithGroupSync();
+    
+    if (gid.x < e_threadBlocks - 1)
+        ScatterDevice(gtid.x, waveSize, gid.x, offsets);
+        
+    if (gid.x == e_threadBlocks - 1)
+        ScatterDevicePartial(gtid.x, waveSize, gid.x, offsets);
 }

--- a/package/Shaders/SortCommon.hlsl
+++ b/package/Shaders/SortCommon.hlsl
@@ -1,0 +1,959 @@
+/******************************************************************************
+ * SortCommon
+ * Common functions for GPUSorting 
+ *
+ * SPDX-License-Identifier: MIT
+ * Copyright Thomas Smith 5/17/2024
+ * https://github.com/b0nes164/GPUSorting
+ *  
+ *  Permission is hereby granted, free of charge, to any person obtaining a copy
+ *  of this software and associated documentation files (the "Software"), to deal
+ *  in the Software without restriction, including without limitation the rights
+ *  to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
+ *  copies of the Software, and to permit persons to whom the Software is
+ *  furnished to do so, subject to the following conditions:
+ *
+ *  The above copyright notice and this permission notice shall be included in all
+ *  copies or substantial portions of the Software.
+ *
+ *  THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+ *  IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+ *  FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+ *  AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+ *  LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+ *  OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE
+ *  SOFTWARE.
+ ******************************************************************************/
+#define KEYS_PER_THREAD     15U 
+#define D_DIM               256U
+#define PART_SIZE           3840U
+#define D_TOTAL_SMEM        4096U
+
+#define RADIX               256U    //Number of digit bins
+#define RADIX_MASK          255U    //Mask of digit bins
+#define HALF_RADIX          128U    //For smaller waves where bit packing is necessary
+#define HALF_MASK           127U    // '' 
+#define RADIX_LOG           8U      //log2(RADIX)
+#define RADIX_PASSES        4U      //(Key width) / RADIX_LOG
+
+cbuffer cbGpuSorting : register(b0)
+{
+    uint e_numKeys;
+    uint e_radixShift;
+    uint e_threadBlocks;
+    uint padding;
+};
+
+#if defined(KEY_UINT)
+RWStructuredBuffer<uint> b_sort;
+RWStructuredBuffer<uint> b_alt;
+#elif defined(KEY_INT)
+RWStructuredBuffer<int> b_sort;
+RWStructuredBuffer<int> b_alt;
+#elif defined(KEY_FLOAT)
+RWStructuredBuffer<float> b_sort;
+RWStructuredBuffer<float> b_alt;
+#endif
+
+#if defined(PAYLOAD_UINT)
+RWStructuredBuffer<uint> b_sortPayload;
+RWStructuredBuffer<uint> b_altPayload;
+#elif defined(PAYLOAD_INT)
+RWStructuredBuffer<int> b_sortPayload;
+RWStructuredBuffer<int> b_altPayload;
+#elif defined(PAYLOAD_FLOAT)
+RWStructuredBuffer<float> b_sortPayload;
+RWStructuredBuffer<float> b_altPayload;
+#endif
+
+groupshared uint g_d[D_TOTAL_SMEM]; //Shared memory for DigitBinningPass and DownSweep kernels
+
+struct KeyStruct
+{
+    uint k[KEYS_PER_THREAD];
+};
+
+struct OffsetStruct
+{
+#if defined(ENABLE_16_BIT)
+    uint16_t o[KEYS_PER_THREAD];
+#else
+    uint o[KEYS_PER_THREAD];
+#endif
+};
+
+struct DigitStruct
+{
+#if defined(ENABLE_16_BIT)
+    uint16_t d[KEYS_PER_THREAD];
+#else
+    uint d[KEYS_PER_THREAD];
+#endif
+};
+
+//*****************************************************************************
+//HELPER FUNCTIONS
+//*****************************************************************************
+//Due to a bug with SPIRV pre 1.6, we cannot use WaveGetLaneCount() to get the currently active wavesize 
+inline uint getWaveSize()
+{
+#if defined(VULKAN)
+    GroupMemoryBarrierWithGroupSync(); //Make absolutely sure the wave is not diverged here
+    return dot(countbits(WaveActiveBallot(true)), uint4(1, 1, 1, 1));
+#else
+    return WaveGetLaneCount();
+#endif
+}
+
+inline uint getWaveIndex(uint gtid, uint waveSize)
+{
+    return gtid / waveSize;
+}
+
+//Radix Tricks by Michael Herf
+//http://stereopsis.com/radix.html
+inline uint FloatToUint(float f)
+{
+    uint mask = -((int) (asuint(f) >> 31)) | 0x80000000;
+    return asuint(f) ^ mask;
+}
+
+inline float UintToFloat(uint u)
+{
+    uint mask = ((u >> 31) - 1) | 0x80000000;
+    return asfloat(u ^ mask);
+}
+
+inline uint IntToUint(int i)
+{
+    return asuint(i ^ 0x80000000);
+}
+
+inline int UintToInt(uint u)
+{
+    return asint(u ^ 0x80000000);
+}
+
+inline uint getWaveCountPass(uint waveSize)
+{
+    return D_DIM / waveSize;
+}
+
+inline uint ExtractDigit(uint key)
+{
+    return key >> e_radixShift & RADIX_MASK;
+}
+
+inline uint ExtractDigit(uint key, uint shift)
+{
+    return key >> shift & RADIX_MASK;
+}
+
+inline uint ExtractPackedIndex(uint key)
+{
+    return key >> (e_radixShift + 1) & HALF_MASK;
+}
+
+inline uint ExtractPackedShift(uint key)
+{
+    return (key >> e_radixShift & 1) ? 16 : 0;
+}
+
+inline uint ExtractPackedValue(uint packed, uint key)
+{
+    return packed >> ExtractPackedShift(key) & 0xffff;
+}
+
+inline uint SubPartSizeWGE16(uint waveSize)
+{
+    return KEYS_PER_THREAD * waveSize;
+}
+
+inline uint SharedOffsetWGE16(uint gtid, uint waveSize)
+{
+    return WaveGetLaneIndex() + getWaveIndex(gtid, waveSize) * SubPartSizeWGE16(waveSize);
+}
+
+inline uint SubPartSizeWLT16(uint waveSize, uint _serialIterations)
+{
+    return KEYS_PER_THREAD * waveSize * _serialIterations;
+}
+
+inline uint SharedOffsetWLT16(uint gtid, uint waveSize, uint _serialIterations)
+{
+    return WaveGetLaneIndex() +
+        (getWaveIndex(gtid, waveSize) / _serialIterations * SubPartSizeWLT16(waveSize, _serialIterations)) +
+        (getWaveIndex(gtid, waveSize) % _serialIterations * waveSize);
+}
+
+inline uint DeviceOffsetWGE16(uint gtid, uint waveSize, uint partIndex)
+{
+    return SharedOffsetWGE16(gtid, waveSize) + partIndex * PART_SIZE;
+}
+
+inline uint DeviceOffsetWLT16(uint gtid, uint waveSize, uint partIndex, uint serialIterations)
+{
+    return SharedOffsetWLT16(gtid, waveSize, serialIterations) + partIndex * PART_SIZE;
+}
+
+inline uint GlobalHistOffset()
+{
+    return e_radixShift << 5;
+}
+
+inline uint WaveHistsSizeWGE16(uint waveSize)
+{
+    return D_DIM / waveSize * RADIX;
+}
+
+inline uint WaveHistsSizeWLT16()
+{
+    return D_TOTAL_SMEM;
+}
+
+//*****************************************************************************
+//FUNCTIONS COMMON TO THE DOWNSWEEP / DIGIT BINNING PASS
+//*****************************************************************************
+//If the size of  a wave is too small, we do not have enough space in
+//shared memory to assign a histogram to each wave, so instead,
+//some operations are peformed serially.
+inline uint SerialIterations(uint waveSize)
+{
+    return (D_DIM / waveSize + 31) >> 5;
+}
+
+inline void ClearWaveHists(uint gtid, uint waveSize)
+{
+    const uint histsEnd = waveSize >= 16 ?
+        WaveHistsSizeWGE16(waveSize) : WaveHistsSizeWLT16();
+    for (uint i = gtid; i < histsEnd; i += D_DIM)
+        g_d[i] = 0;
+}
+
+inline void LoadKey(inout uint key, uint index)
+{
+#if defined(KEY_UINT)
+    key = b_sort[index];
+#elif defined(KEY_INT)
+    key = UintToInt(b_sort[index]);
+#elif defined(KEY_FLOAT)
+    key = FloatToUint(b_sort[index]);
+#endif
+}
+
+inline void LoadDummyKey(inout uint key)
+{
+    key = 0xffffffff;
+}
+
+inline KeyStruct LoadKeysWGE16(uint gtid, uint waveSize, uint partIndex)
+{
+    KeyStruct keys;
+    [unroll]
+    for (uint i = 0, t = DeviceOffsetWGE16(gtid, waveSize, partIndex);
+        i < KEYS_PER_THREAD;
+        ++i, t += waveSize)
+    {
+        LoadKey(keys.k[i], t);
+    }
+    return keys;
+}
+
+inline KeyStruct LoadKeysWLT16(uint gtid, uint waveSize, uint partIndex, uint serialIterations)
+{
+    KeyStruct keys;
+    [unroll]
+    for (uint i = 0, t = DeviceOffsetWLT16(gtid, waveSize, partIndex, serialIterations);
+        i < KEYS_PER_THREAD;
+        ++i, t += waveSize * serialIterations)
+    {
+        LoadKey(keys.k[i], t);
+    }
+    return keys;
+}
+
+inline KeyStruct LoadKeysPartialWGE16(uint gtid, uint waveSize, uint partIndex)
+{
+    KeyStruct keys;
+    [unroll]
+    for (uint i = 0, t = DeviceOffsetWGE16(gtid, waveSize, partIndex);
+        i < KEYS_PER_THREAD;
+        ++i, t += waveSize)
+    {
+        if (t < e_numKeys)
+            LoadKey(keys.k[i], t);
+        else
+            LoadDummyKey(keys.k[i]);
+    }
+    return keys;
+}
+
+inline KeyStruct LoadKeysPartialWLT16(uint gtid, uint waveSize, uint partIndex, uint serialIterations)
+{
+    KeyStruct keys;
+    [unroll]
+    for (uint i = 0, t = DeviceOffsetWLT16(gtid, waveSize, partIndex, serialIterations);
+        i < KEYS_PER_THREAD;
+        ++i, t += waveSize * serialIterations)
+    {
+        if (t < e_numKeys)
+            LoadKey(keys.k[i], t);
+        else
+            LoadDummyKey(keys.k[i]);
+    }
+    return keys;
+}
+
+inline uint WaveFlagsWGE16(uint waveSize)
+{
+    return (waveSize & 31) ? (1U << waveSize) - 1 : 0xffffffff;
+}
+
+inline uint WaveFlagsWLT16(uint waveSize)
+{
+    return (1U << waveSize) - 1;;
+}
+
+inline void WarpLevelMultiSplitWGE16(uint key, inout uint4 waveFlags)
+{
+    [unroll]
+    for (uint k = 0; k < RADIX_LOG; ++k)
+    {
+        const uint currentBit = 1 << k + e_radixShift;
+        const bool t = (key & currentBit) != 0;
+        GroupMemoryBarrierWithGroupSync();  //Play on the safe side, throw in a barrier for convergence
+        const uint4 ballot = WaveActiveBallot(t);
+        if(t)
+            waveFlags &= ballot;
+        else
+            waveFlags &= (~ballot);
+    }
+}
+
+inline uint2 CountBitsWGE16(uint waveSize, uint ltMask, uint4 waveFlags)
+{
+    uint2 count = uint2(0, 0);
+    
+    for(uint wavePart = 0; wavePart < waveSize; wavePart += 32)
+    {
+        if (WaveGetLaneIndex() >= wavePart)
+        {
+            uint t = countbits(waveFlags[wavePart >> 5]);
+            if (WaveGetLaneIndex() >= wavePart + 32)
+                count.x += t;
+            else
+                count.x += countbits(waveFlags[wavePart >> 5] & ltMask);
+            count.y += t;
+        }
+    }
+    
+    return count;
+}
+
+inline void WarpLevelMultiSplitWLT16(uint key, inout uint waveFlags)
+{
+    [unroll]
+    for (uint k = 0; k < RADIX_LOG; ++k)
+    {
+        const bool t = key >> (k + e_radixShift) & 1;
+        waveFlags &= (t ? 0 : 0xffffffff) ^ (uint) WaveActiveBallot(t);
+    }
+}
+
+inline OffsetStruct RankKeysWGE16(
+    uint waveSize,
+    uint waveOffset,
+    KeyStruct keys)
+{
+    OffsetStruct offsets;
+    const uint initialFlags = WaveFlagsWGE16(waveSize);
+    const uint ltMask = (1U << (WaveGetLaneIndex() & 31)) - 1;
+    
+    [unroll]
+    for (uint i = 0; i < KEYS_PER_THREAD; ++i)
+    {
+        uint4 waveFlags = initialFlags;
+        WarpLevelMultiSplitWGE16(keys.k[i], waveFlags);
+        
+        const uint index = ExtractDigit(keys.k[i]) + waveOffset;
+        const uint2 bitCount = CountBitsWGE16(waveSize, ltMask, waveFlags);
+        
+        offsets.o[i] = g_d[index] + bitCount.x;
+        GroupMemoryBarrierWithGroupSync();
+        if (bitCount.x == 0)
+            g_d[index] += bitCount.y;
+        GroupMemoryBarrierWithGroupSync();
+    }
+    
+    return offsets;
+}
+
+inline OffsetStruct RankKeysWLT16(uint waveSize, uint waveIndex, KeyStruct keys, uint serialIterations)
+{
+    OffsetStruct offsets;
+    const uint ltMask = (1U << WaveGetLaneIndex()) - 1;
+    const uint initialFlags = WaveFlagsWLT16(waveSize);
+    
+    [unroll]
+    for (uint i = 0; i < KEYS_PER_THREAD; ++i)
+    {
+        uint waveFlags = initialFlags;
+        WarpLevelMultiSplitWLT16(keys.k[i], waveFlags);
+        
+        const uint index = ExtractPackedIndex(keys.k[i]) +
+                (waveIndex / serialIterations * HALF_RADIX);
+        
+        const uint peerBits = countbits(waveFlags & ltMask);
+        for (uint k = 0; k < serialIterations; ++k)
+        {
+            if (waveIndex % serialIterations == k)
+                offsets.o[i] = ExtractPackedValue(g_d[index], keys.k[i]) + peerBits;
+            
+            GroupMemoryBarrierWithGroupSync();
+            if (waveIndex % serialIterations == k && peerBits == 0)
+            {
+                InterlockedAdd(g_d[index],
+                    countbits(waveFlags) << ExtractPackedShift(keys.k[i]));
+            }
+            GroupMemoryBarrierWithGroupSync();
+        }
+    }
+    
+    return offsets;
+}
+
+inline uint WaveHistInclusiveScanCircularShiftWGE16(uint gtid, uint waveSize)
+{
+    uint histReduction = g_d[gtid];
+    for (uint i = gtid + RADIX; i < WaveHistsSizeWGE16(waveSize); i += RADIX)
+    {
+        histReduction += g_d[i];
+        g_d[i] = histReduction - g_d[i];
+    }
+    return histReduction;
+}
+
+inline uint WaveHistInclusiveScanCircularShiftWLT16(uint gtid)
+{
+    uint histReduction = g_d[gtid];
+    for (uint i = gtid + HALF_RADIX; i < WaveHistsSizeWLT16(); i += HALF_RADIX)
+    {
+        histReduction += g_d[i];
+        g_d[i] = histReduction - g_d[i];
+    }
+    return histReduction;
+}
+
+inline void WaveHistReductionExclusiveScanWGE16(uint gtid, uint waveSize, uint histReduction)
+{
+    if (gtid < RADIX)
+    {
+        const uint laneMask = waveSize - 1;
+        g_d[((WaveGetLaneIndex() + 1) & laneMask) + (gtid & ~laneMask)] = histReduction;
+    }
+    GroupMemoryBarrierWithGroupSync();
+                
+    if (gtid < RADIX / waveSize)
+    {
+        g_d[gtid * waveSize] =
+            WavePrefixSum(g_d[gtid * waveSize]);
+    }
+    GroupMemoryBarrierWithGroupSync();
+    
+    uint t = WaveReadLaneAt(g_d[gtid], 0);
+    if (gtid < RADIX && WaveGetLaneIndex())
+        g_d[gtid] += t;
+}
+
+//inclusive/exclusive prefix sum up the histograms,
+//use a blelloch scan for in place packed exclusive
+inline void WaveHistReductionExclusiveScanWLT16(uint gtid)
+{
+    uint shift = 1;
+    for (uint j = RADIX >> 2; j > 0; j >>= 1)
+    {
+        GroupMemoryBarrierWithGroupSync();
+        if (gtid < j)
+        {
+            g_d[((((gtid << 1) + 2) << shift) - 1) >> 1] +=
+                g_d[((((gtid << 1) + 1) << shift) - 1) >> 1] & 0xffff0000;
+        }
+        shift++;
+    }
+    GroupMemoryBarrierWithGroupSync();
+                
+    if (gtid == 0)
+        g_d[HALF_RADIX - 1] &= 0xffff;
+                
+    for (uint j = 1; j < RADIX >> 1; j <<= 1)
+    {
+        --shift;
+        GroupMemoryBarrierWithGroupSync();
+        if (gtid < j)
+        {
+            const uint t = ((((gtid << 1) + 1) << shift) - 1) >> 1;
+            const uint t2 = ((((gtid << 1) + 2) << shift) - 1) >> 1;
+            const uint t3 = g_d[t];
+            g_d[t] = (g_d[t] & 0xffff) | (g_d[t2] & 0xffff0000);
+            g_d[t2] += t3 & 0xffff0000;
+        }
+    }
+
+    GroupMemoryBarrierWithGroupSync();
+    if (gtid < HALF_RADIX)
+    {
+        const uint t = g_d[gtid];
+        g_d[gtid] = (t >> 16) + (t << 16) + (t & 0xffff0000);
+    }
+}
+
+inline void UpdateOffsetsWGE16(
+    uint gtid,
+    uint waveSize,
+    inout OffsetStruct offsets,
+    KeyStruct keys)
+{
+    if (gtid >= waveSize)
+    {
+        const uint t = getWaveIndex(gtid, waveSize) * RADIX;
+        [unroll]
+        for (uint i = 0; i < KEYS_PER_THREAD; ++i)
+        {
+            const uint t2 = ExtractDigit(keys.k[i]);
+            offsets.o[i] += g_d[t2 + t] + g_d[t2];
+        }
+    }
+    else
+    {
+        [unroll]
+        for (uint i = 0; i < KEYS_PER_THREAD; ++i)
+            offsets.o[i] += g_d[ExtractDigit(keys.k[i])];
+    }
+}
+
+inline void UpdateOffsetsWLT16(
+    uint gtid,
+    uint waveSize,
+    uint serialIterations,
+    inout OffsetStruct offsets,
+    KeyStruct keys)
+{
+    if (gtid >= waveSize * serialIterations)
+    {
+        const uint t = getWaveIndex(gtid, waveSize) / serialIterations * HALF_RADIX;
+        [unroll]
+        for (uint i = 0; i < KEYS_PER_THREAD; ++i)
+        {
+            const uint t2 = ExtractPackedIndex(keys.k[i]);
+            offsets.o[i] += ExtractPackedValue(g_d[t2 + t] + g_d[t2], keys.k[i]);
+        }
+    }
+    else
+    {
+        [unroll]
+        for (uint i = 0; i < KEYS_PER_THREAD; ++i)
+            offsets.o[i] += ExtractPackedValue(g_d[ExtractPackedIndex(keys.k[i])], keys.k[i]);
+    }
+}
+
+inline void ScatterKeysShared(OffsetStruct offsets, KeyStruct keys)
+{
+    [unroll]
+    for (uint i = 0; i < KEYS_PER_THREAD; ++i)
+        g_d[offsets.o[i]] = keys.k[i];
+}
+
+inline uint DescendingIndex(uint deviceIndex)
+{
+    return e_numKeys - deviceIndex - 1;
+}
+
+inline void WriteKey(uint deviceIndex, uint groupSharedIndex)
+{
+#if defined(KEY_UINT)
+    b_alt[deviceIndex] = g_d[groupSharedIndex];
+#elif defined(KEY_INT)
+    b_alt[deviceIndex] = UintToInt(g_d[groupSharedIndex]);
+#elif defined(KEY_FLOAT)
+    b_alt[deviceIndex] = UintToFloat(g_d[groupSharedIndex]);
+#endif
+}
+
+inline void LoadPayload(inout uint payload, uint deviceIndex)
+{
+#if defined(PAYLOAD_UINT)
+    payload = b_sortPayload[deviceIndex];
+#elif defined(PAYLOAD_INT) || defined(PAYLOAD_FLOAT)
+    payload = asuint(b_sortPayload[deviceIndex]);
+#endif
+}
+
+inline void ScatterPayloadsShared(OffsetStruct offsets, KeyStruct payloads)
+{
+    ScatterKeysShared(offsets, payloads);
+}
+
+inline void WritePayload(uint deviceIndex, uint groupSharedIndex)
+{
+#if defined(PAYLOAD_UINT)
+    b_altPayload[deviceIndex] = g_d[groupSharedIndex];
+#elif defined(PAYLOAD_INT)
+    b_altPayload[deviceIndex] = asint(g_d[groupSharedIndex]);
+#elif defined(PAYLOAD_FLOAT)
+    b_altPayload[deviceIndex] = asfloat(g_d[groupSharedIndex]);
+#endif
+}
+
+//*****************************************************************************
+//SCATTERING: FULL PARTITIONS
+//*****************************************************************************
+//KEYS ONLY
+inline void ScatterKeysOnlyDeviceAscending(uint gtid)
+{
+    for (uint i = gtid; i < PART_SIZE; i += D_DIM)
+        WriteKey(g_d[ExtractDigit(g_d[i]) + PART_SIZE] + i, i);
+}
+
+inline void ScatterKeysOnlyDeviceDescending(uint gtid)
+{
+    if (e_radixShift == 24)
+    {
+        for (uint i = gtid; i < PART_SIZE; i += D_DIM)
+            WriteKey(DescendingIndex(g_d[ExtractDigit(g_d[i]) + PART_SIZE] + i), i);
+    }
+    else
+    {
+        ScatterKeysOnlyDeviceAscending(gtid);
+    }
+}
+
+inline void ScatterKeysOnlyDevice(uint gtid)
+{
+#if defined(SHOULD_ASCEND)
+    ScatterKeysOnlyDeviceAscending(gtid);
+#else
+    ScatterKeysOnlyDeviceDescending(gtid);
+#endif
+}
+
+//KEY VALUE PAIRS
+inline void ScatterPairsKeyPhaseAscending(
+    uint gtid,
+    inout DigitStruct digits)
+{
+    [unroll]
+    for (uint i = 0, t = gtid; i < KEYS_PER_THREAD; ++i, t += D_DIM)
+    {
+        digits.d[i] = ExtractDigit(g_d[t]);
+        WriteKey(g_d[digits.d[i] + PART_SIZE] + t, t);
+    }
+}
+
+inline void ScatterPairsKeyPhaseDescending(
+    uint gtid,
+    inout DigitStruct digits)
+{
+    if (e_radixShift == 24)
+    {
+        [unroll]
+        for (uint i = 0, t = gtid; i < KEYS_PER_THREAD; ++i, t += D_DIM)
+        {
+            digits.d[i] = ExtractDigit(g_d[t]);
+            WriteKey(DescendingIndex(g_d[digits.d[i] + PART_SIZE] + t), t);
+        }
+    }
+    else
+    {
+        ScatterPairsKeyPhaseAscending(gtid, digits);
+    }
+}
+
+inline void LoadPayloadsWGE16(
+    uint gtid,
+    uint waveSize,
+    uint partIndex,
+    inout KeyStruct payloads)
+{
+    [unroll]
+    for (uint i = 0, t = DeviceOffsetWGE16(gtid, waveSize, partIndex);
+        i < KEYS_PER_THREAD;
+        ++i, t += waveSize)
+    {
+        LoadPayload(payloads.k[i], t);
+    }
+}
+
+inline void LoadPayloadsWLT16(
+    uint gtid,
+    uint waveSize,
+    uint partIndex,
+    uint serialIterations,
+    inout KeyStruct payloads)
+{
+    [unroll]
+    for (uint i = 0, t = DeviceOffsetWLT16(gtid, waveSize, partIndex, serialIterations);
+        i < KEYS_PER_THREAD;
+        ++i, t += waveSize * serialIterations)
+    {
+        LoadPayload(payloads.k[i], t);
+    }
+}
+
+inline void ScatterPayloadsAscending(uint gtid, DigitStruct digits)
+{
+    [unroll]
+    for (uint i = 0, t = gtid; i < KEYS_PER_THREAD; ++i, t += D_DIM)
+        WritePayload(g_d[digits.d[i] + PART_SIZE] + t, t);
+}
+
+inline void ScatterPayloadsDescending(uint gtid, DigitStruct digits)
+{
+    if (e_radixShift == 24)
+    {
+        [unroll]
+        for (uint i = 0, t = gtid; i < KEYS_PER_THREAD; ++i, t += D_DIM)
+            WritePayload(DescendingIndex(g_d[digits.d[i] + PART_SIZE] + t), t);
+    }
+    else
+    {
+        ScatterPayloadsAscending(gtid, digits);
+    }
+}
+
+inline void ScatterPairsDevice(
+    uint gtid,
+    uint waveSize,
+    uint partIndex,
+    OffsetStruct offsets)
+{
+    DigitStruct digits;
+#if defined(SHOULD_ASCEND)
+    ScatterPairsKeyPhaseAscending(gtid, digits);
+#else
+    ScatterPairsKeyPhaseDescending(gtid, digits);
+#endif
+    GroupMemoryBarrierWithGroupSync();
+    
+    KeyStruct payloads;
+    if (waveSize >= 16)
+        LoadPayloadsWGE16(gtid, waveSize, partIndex, payloads);
+    else
+        LoadPayloadsWLT16(gtid, waveSize, partIndex, SerialIterations(waveSize), payloads);
+    ScatterPayloadsShared(offsets, payloads);
+    GroupMemoryBarrierWithGroupSync();
+    
+#if defined(SHOULD_ASCEND)
+    ScatterPayloadsAscending(gtid, digits);
+#else
+    ScatterPayloadsDescending(gtid, digits);
+#endif
+}
+
+inline void ScatterDevice(
+    uint gtid,
+    uint waveSize,
+    uint partIndex,
+    OffsetStruct offsets)
+{
+#if defined(SORT_PAIRS)
+    ScatterPairsDevice(
+        gtid,
+        waveSize,
+        partIndex,
+        offsets);
+#else
+    ScatterKeysOnlyDevice(gtid);
+#endif
+}
+
+//*****************************************************************************
+//SCATTERING: PARTIAL PARTITIONS
+//*****************************************************************************
+//KEYS ONLY
+inline void ScatterKeysOnlyDevicePartialAscending(uint gtid, uint finalPartSize)
+{
+    for (uint i = gtid; i < PART_SIZE; i += D_DIM)
+    {
+        if (i < finalPartSize)
+            WriteKey(g_d[ExtractDigit(g_d[i]) + PART_SIZE] + i, i);
+    }
+}
+
+inline void ScatterKeysOnlyDevicePartialDescending(uint gtid, uint finalPartSize)
+{
+    if (e_radixShift == 24)
+    {
+        for (uint i = gtid; i < PART_SIZE; i += D_DIM)
+        {
+            if (i < finalPartSize)
+                WriteKey(DescendingIndex(g_d[ExtractDigit(g_d[i]) + PART_SIZE] + i), i);
+        }
+    }
+    else
+    {
+        ScatterKeysOnlyDevicePartialAscending(gtid, finalPartSize);
+    }
+}
+
+inline void ScatterKeysOnlyDevicePartial(uint gtid, uint partIndex)
+{
+    const uint finalPartSize = e_numKeys - partIndex * PART_SIZE;
+#if defined(SHOULD_ASCEND)
+    ScatterKeysOnlyDevicePartialAscending(gtid, finalPartSize);
+#else
+    ScatterKeysOnlyDevicePartialDescending(gtid, finalPartSize);
+#endif
+}
+
+//KEY VALUE PAIRS
+inline void ScatterPairsKeyPhaseAscendingPartial(
+    uint gtid,
+    uint finalPartSize,
+    inout DigitStruct digits)
+{
+    [unroll]
+    for (uint i = 0, t = gtid; i < KEYS_PER_THREAD; ++i, t += D_DIM)
+    {
+        if (t < finalPartSize)
+        {
+            digits.d[i] = ExtractDigit(g_d[t]);
+            WriteKey(g_d[digits.d[i] + PART_SIZE] + t, t);
+        }
+    }
+}
+
+inline void ScatterPairsKeyPhaseDescendingPartial(
+    uint gtid,
+    uint finalPartSize,
+    inout DigitStruct digits)
+{
+    if (e_radixShift == 24)
+    {
+        [unroll]
+        for (uint i = 0, t = gtid; i < KEYS_PER_THREAD; ++i, t += D_DIM)
+        {
+            if (t < finalPartSize)
+            {
+                digits.d[i] = ExtractDigit(g_d[t]);
+                WriteKey(DescendingIndex(g_d[digits.d[i] + PART_SIZE] + t), t);
+            }
+        }
+    }
+    else
+    {
+        ScatterPairsKeyPhaseAscendingPartial(gtid, finalPartSize, digits);
+    }
+}
+
+inline void LoadPayloadsPartialWGE16(
+    uint gtid,
+    uint waveSize,
+    uint partIndex,
+    inout KeyStruct payloads)
+{
+    [unroll]
+    for (uint i = 0, t = DeviceOffsetWGE16(gtid, waveSize, partIndex);
+        i < KEYS_PER_THREAD;
+        ++i, t += waveSize)
+    {
+        if (t < e_numKeys)
+            LoadPayload(payloads.k[i], t);
+    }
+}
+
+inline void LoadPayloadsPartialWLT16(
+    uint gtid,
+    uint waveSize,
+    uint partIndex,
+    uint serialIterations,
+    inout KeyStruct payloads)
+{
+    [unroll]
+    for (uint i = 0, t = DeviceOffsetWLT16(gtid, waveSize, partIndex, serialIterations);
+        i < KEYS_PER_THREAD;
+        ++i, t += waveSize * serialIterations)
+    {
+        if (t < e_numKeys)
+            LoadPayload(payloads.k[i], t);
+    }
+}
+
+inline void ScatterPayloadsAscendingPartial(
+    uint gtid,
+    uint finalPartSize,
+    DigitStruct digits)
+{
+    [unroll]
+    for (uint i = 0, t = gtid; i < KEYS_PER_THREAD; ++i, t += D_DIM)
+    {
+        if (t < finalPartSize)
+            WritePayload(g_d[digits.d[i] + PART_SIZE] + t, t);
+    }
+}
+
+inline void ScatterPayloadsDescendingPartial(
+    uint gtid,
+    uint finalPartSize,
+    DigitStruct digits)
+{
+    if (e_radixShift == 24)
+    {
+        [unroll]
+        for (uint i = 0, t = gtid; i < KEYS_PER_THREAD; ++i, t += D_DIM)
+        {
+            if (t < finalPartSize)
+                WritePayload(DescendingIndex(g_d[digits.d[i] + PART_SIZE] + t), t);
+        }
+    }
+    else
+    {
+        ScatterPayloadsAscendingPartial(gtid, finalPartSize, digits);
+    }
+}
+
+inline void ScatterPairsDevicePartial(
+    uint gtid,
+    uint waveSize,
+    uint partIndex,
+    OffsetStruct offsets)
+{
+    DigitStruct digits;
+    const uint finalPartSize = e_numKeys - partIndex * PART_SIZE;
+#if defined(SHOULD_ASCEND)
+    ScatterPairsKeyPhaseAscendingPartial(gtid, finalPartSize, digits);
+#else
+    ScatterPairsKeyPhaseDescendingPartial(gtid, finalPartSize, digits);
+#endif
+    GroupMemoryBarrierWithGroupSync();
+    
+    KeyStruct payloads;
+    if (waveSize >= 16)
+        LoadPayloadsPartialWGE16(gtid, waveSize, partIndex, payloads);
+    else
+        LoadPayloadsPartialWLT16(gtid, waveSize, partIndex, SerialIterations(waveSize), payloads);
+    ScatterPayloadsShared(offsets, payloads);
+    GroupMemoryBarrierWithGroupSync();
+    
+#if defined(SHOULD_ASCEND)
+    ScatterPayloadsAscendingPartial(gtid, finalPartSize, digits);
+#else
+    ScatterPayloadsDescendingPartial(gtid, finalPartSize, digits);
+#endif
+}
+
+inline void ScatterDevicePartial(
+    uint gtid,
+    uint waveSize,
+    uint partIndex,
+    OffsetStruct offsets)
+{
+#if defined(SORT_PAIRS)
+    ScatterPairsDevicePartial(
+        gtid,
+        waveSize,
+        partIndex,
+        offsets);
+#else
+    ScatterKeysOnlyDevicePartial(gtid, partIndex);
+#endif
+}

--- a/package/Shaders/SortCommon.hlsl
+++ b/package/Shaders/SortCommon.hlsl
@@ -336,15 +336,15 @@ inline uint2 CountBitsWGE16(uint waveSize, uint ltMask, uint4 waveFlags)
     
     for(uint wavePart = 0; wavePart < waveSize; wavePart += 32)
     {
+        uint t = countbits(waveFlags[wavePart >> 5]);
         if (WaveGetLaneIndex() >= wavePart)
         {
-            uint t = countbits(waveFlags[wavePart >> 5]);
             if (WaveGetLaneIndex() >= wavePart + 32)
                 count.x += t;
             else
                 count.x += countbits(waveFlags[wavePart >> 5] & ltMask);
-            count.y += t;
         }
+        count.y += t;
     }
     
     return count;

--- a/package/Shaders/SortCommon.hlsl.meta
+++ b/package/Shaders/SortCommon.hlsl.meta
@@ -1,0 +1,7 @@
+fileFormatVersion: 2
+guid: 268e5936ab6d79f4b8aeef8f5d14e7ee
+ShaderIncludeImporter:
+  externalObjects: {}
+  userData: 
+  assetBundleName: 
+  assetBundleVariant: 

--- a/package/Shaders/SplatUtilities.compute
+++ b/package/Shaders/SplatUtilities.compute
@@ -18,6 +18,11 @@
 #pragma kernel CSCopySplats
 
 // DeviceRadixSort
+#pragma multi_compile __ KEY_UINT KEY_INT KEY_FLOAT
+#pragma multi_compile __ PAYLOAD_UINT PAYLOAD_INT PAYLOAD_FLOAT
+#pragma multi_compile __ SHOULD_ASCEND
+#pragma multi_compile __ SORT_PAIRS
+#pragma multi_compile __ VULKAN
 #pragma kernel InitDeviceRadixSort
 #pragma kernel Upsweep
 #pragma kernel Scan
@@ -25,7 +30,7 @@
 
 // GPU sorting needs wave ops
 #pragma require wavebasic
-
+#pragma require waveballot
 #pragma use_dxc
 
 #include "DeviceRadixSort.hlsl"

--- a/package/Shaders/SplatUtilities.compute
+++ b/package/Shaders/SplatUtilities.compute
@@ -30,12 +30,11 @@
 
 #include "DeviceRadixSort.hlsl"
 #include "GaussianSplatting.hlsl"
+#include "UnityCG.cginc"
 
 float4x4 _MatrixObjectToWorld;
 float4x4 _MatrixWorldToObject;
-float4x4 _MatrixVP;
 float4x4 _MatrixMV;
-float4x4 _MatrixP;
 float4 _VecScreenParams;
 float4 _VecWorldSpaceCameraPos;
 int _SelectionMode;
@@ -193,7 +192,7 @@ void CSCalcViewData (uint3 id : SV_DispatchThreadID)
     SplatViewData view = (SplatViewData)0;
     
     float3 centerWorldPos = mul(_MatrixObjectToWorld, float4(splat.pos,1)).xyz;
-    float4 centerClipPos = mul(_MatrixVP, float4(centerWorldPos, 1));
+    float4 centerClipPos = mul(UNITY_MATRIX_VP, float4(centerWorldPos, 1));
     half opacityScale = _SplatOpacityScale;
     float splatScale = _SplatScale;
 
@@ -229,7 +228,7 @@ void CSCalcViewData (uint3 id : SV_DispatchThreadID)
         float splatScale2 = splatScale * splatScale;
         cov3d0 *= splatScale2;
         cov3d1 *= splatScale2;
-        float3 cov2d = CalcCovariance2D(splat.pos, cov3d0, cov3d1, _MatrixMV, _MatrixP, _VecScreenParams);
+        float3 cov2d = CalcCovariance2D(splat.pos, cov3d0, cov3d1, _MatrixMV, UNITY_MATRIX_P, _VecScreenParams);
         
         DecomposeCovariance(cov2d, view.axis1, view.axis2);
 
@@ -398,7 +397,7 @@ void CSSelectionUpdate (uint3 id : SV_DispatchThreadID)
         return;
 
     float3 centerWorldPos = mul(_MatrixObjectToWorld, float4(pos,1)).xyz;
-    float4 centerClipPos = mul(_MatrixVP, float4(centerWorldPos, 1));
+    float4 centerClipPos = mul(UNITY_MATRIX_VP, float4(centerWorldPos, 1));
     bool behindCam = centerClipPos.w <= 0;
     if (behindCam)
         return;

--- a/projects/GaussianExample/ProjectSettings/ProjectSettings.asset
+++ b/projects/GaussianExample/ProjectSettings/ProjectSettings.asset
@@ -17,7 +17,7 @@ PlayerSettings:
   defaultCursor: {fileID: 0}
   cursorHotspot: {x: 0, y: 0}
   m_SplashScreenBackgroundColor: {r: 0.13725491, g: 0.12156863, b: 0.1254902, a: 1}
-  m_ShowUnitySplashScreen: 1
+  m_ShowUnitySplashScreen: 0
   m_ShowUnitySplashLogo: 1
   m_SplashScreenOverlayOpacity: 1
   m_SplashScreenAnimation: 1
@@ -341,7 +341,7 @@ PlayerSettings:
     m_APIs: 0b000000
     m_Automatic: 1
   - m_BuildTarget: WindowsStandaloneSupport
-    m_APIs: 1500000012000000
+    m_APIs: 1200000015000000
     m_Automatic: 0
   m_BuildTargetVRSettings:
   - m_BuildTarget: Standalone

--- a/projects/GaussianExample/ProjectSettings/ProjectSettings.asset
+++ b/projects/GaussianExample/ProjectSettings/ProjectSettings.asset
@@ -17,7 +17,7 @@ PlayerSettings:
   defaultCursor: {fileID: 0}
   cursorHotspot: {x: 0, y: 0}
   m_SplashScreenBackgroundColor: {r: 0.13725491, g: 0.12156863, b: 0.1254902, a: 1}
-  m_ShowUnitySplashScreen: 0
+  m_ShowUnitySplashScreen: 1
   m_ShowUnitySplashLogo: 1
   m_SplashScreenOverlayOpacity: 1
   m_SplashScreenAnimation: 1
@@ -341,7 +341,7 @@ PlayerSettings:
     m_APIs: 0b000000
     m_Automatic: 1
   - m_BuildTarget: WindowsStandaloneSupport
-    m_APIs: 1200000015000000
+    m_APIs: 1500000012000000
     m_Automatic: 0
   m_BuildTargetVRSettings:
   - m_BuildTarget: Standalone


### PR DESCRIPTION
Hi,

this adds VR support as mentioned in #17. It is based on the work in https://github.com/ninjamode/Unity-VR-Gaussian-Splatting

Changes are:
- Replace P and VP matrice usage with Unity builtins
- Update DeviceRadixSort to an newer version that has better GPU support (needed for Quest 3), see https://github.com/b0nes164/GPUSorting/issues/4
- Uses the eye texture size in screen size calculations when available

Not ported over is the sorting for eye center. It's quite helpful, but not implemented nice enough for me to want to port it over, so maybe should be mentioned in the readme as a optimization that's maybe worth it? Not strictly needed, especially with Desktop VR. Sample implementation can be found here: https://github.com/ninjamode/Unity-VR-Gaussian-Splatting/blob/main/package/Runtime/GaussianSplatRenderer.cs

Anyway, this does not add any Readme changes, but you might want to adjust the VR notice.

Tested and works on: Desktop Steam VR (HTC Vive), Varjo Devices (tested on Aero), Quest 3 and Quest Pro via Link and standalone. Probably also works on other devices, such as mobile phones? It's to keep in mind that GS rendering uses quite some resources, so keep the Gaussian count low on mobile devices, try not to be super close (fillrate issue?), don't sort every frame.

How To:
1. Use URP (Standard Pipeline has more matrix issues. Can probably be fixed, I didn't see the point)
2. Enable XR plugin Management
3. Enable and start OpenXR on init
4. Set Render Mode to Multi-Pass

Thats it. 
If you ever get the chance to try it you should, it's quite impressive. If you feel like it, I'd be happy if you could mention my repository and/or the fact that this was done as a part of a research project that can be cited (see https://github.com/ninjamode/Unity-VR-Gaussian-Splatting/?tab=readme-ov-file#related ).

In any case, thank you for this project, and let me know If you'd like to see any changed. Maybe someone with a VR headset can test this and confirm I didn't accidentally break anything.