### PR TITLE
[VR] Single Pass Instanced/Multiview Support for Gaussian Splatting in URP

### DIFF
--- a/package/Editor/GaussianSplatRendererEditor.cs
+++ b/package/Editor/GaussianSplatRendererEditor.cs
@@ -27,6 +27,7 @@ namespace GaussianSplatting.Editor
         SerializedProperty m_PropSHOrder;
         SerializedProperty m_PropSHOnly;
         SerializedProperty m_PropSortNthFrame;
+        SerializedProperty m_PropSortPerEye;
         SerializedProperty m_PropRenderMode;
         SerializedProperty m_PropPointDisplaySize;
         SerializedProperty m_PropCutouts;
@@ -67,6 +68,7 @@ namespace GaussianSplatting.Editor
             m_PropSHOrder = serializedObject.FindProperty("m_SHOrder");
             m_PropSHOnly = serializedObject.FindProperty("m_SHOnly");
             m_PropSortNthFrame = serializedObject.FindProperty("m_SortNthFrame");
+            m_PropSortPerEye = serializedObject.FindProperty("m_SortPerEye");
             m_PropRenderMode = serializedObject.FindProperty("m_RenderMode");
             m_PropPointDisplaySize = serializedObject.FindProperty("m_PointDisplaySize");
             m_PropCutouts = serializedObject.FindProperty("m_Cutouts");
@@ -111,7 +113,7 @@ namespace GaussianSplatting.Editor
             EditorGUILayout.PropertyField(m_PropSHOrder);
             EditorGUILayout.PropertyField(m_PropSHOnly);
             EditorGUILayout.PropertyField(m_PropSortNthFrame);
-
+            EditorGUILayout.PropertyField(m_PropSortPerEye);
             EditorGUILayout.Space();
             GUILayout.Label("Debugging Tweaks", EditorStyles.boldLabel);
             EditorGUILayout.PropertyField(m_PropRenderMode);

--- a/package/Runtime/GaussianSplatRenderer.cs
+++ b/package/Runtime/GaussianSplatRenderer.cs
@@ -211,7 +211,7 @@ namespace GaussianSplatting.Runtime
             {
                 // Set the eye index for this specific render
                 item.mpb.SetInteger(GaussianSplatRenderer.Props.EyeIndex, eyeIndex);
-                item.mpb.SetInteger(GaussianSplatRenderer.Props.IsStereo, 1);
+                item.mpb.SetInteger(GaussianSplatRenderer.Props.IsStereo, (eyeIndex == -1) ? 0 : 1);
 
                 // Draw
                 cmb.BeginSample(s_ProfDraw);

--- a/package/Runtime/GaussianSplatRenderer.cs
+++ b/package/Runtime/GaussianSplatRenderer.cs
@@ -691,7 +691,8 @@ namespace GaussianSplatting.Runtime
             cmb.SetComputeMatrixParam(m_CSSplatUtilities, Props.MatrixWorldToObject, matW2O);
             bool isStereo = XRSettings.enabled && cam.stereoEnabled && 
                             (XRSettings.stereoRenderingMode == XRSettings.StereoRenderingMode.SinglePassInstanced || 
-                             XRSettings.stereoRenderingMode == XRSettings.StereoRenderingMode.SinglePassMultiview);
+                             XRSettings.stereoRenderingMode == XRSettings.StereoRenderingMode.SinglePassMultiview) &&
+                            !Application.isEditor;
             
             if (isStereo)
             {

--- a/package/Runtime/GaussianSplatRenderer.cs
+++ b/package/Runtime/GaussianSplatRenderer.cs
@@ -207,13 +207,13 @@ namespace GaussianSplatting.Runtime
         }
 
         // ReSharper disable once MemberCanBePrivate.Global - used by HDRP/URP features that are not always compiled
-        public Material SortAndRenderSplats(Camera cam, CommandBuffer cmb)
+        public Material SortAndRenderSplats(Camera cam, CommandBuffer cmb, int eyeIndex = -1)
         {
             // Prepare the splats (sort and calculate view data)
             var renderData = PrepareSplats(cam, cmb);
             
             // Render the prepared splats
-            RenderPreparedSplats(cmb, -1);
+            RenderPreparedSplats(cmb, eyeIndex);
             
             // Return the composite material
             return renderData.matComposite;
@@ -260,6 +260,17 @@ namespace GaussianSplatting.Runtime
             m_CommandBuffer.EndSample(s_ProfCompose);
             m_CommandBuffer.ReleaseTemporaryRT(GaussianSplatRenderer.Props.GaussianSplatRT);
         }
+        
+        // Checks if any active splats require per-eye sorting
+        public bool RequiresPerEyeSorting()
+        {
+            foreach (var item in m_ActiveSplats)
+            {
+                if (item.Item1.m_SortPerEye)
+                    return true;
+            }
+            return false;
+        }
     }
 
     [ExecuteInEditMode]
@@ -288,6 +299,8 @@ namespace GaussianSplatting.Runtime
         public bool m_SHOnly;
         [Range(1,30)] [Tooltip("Sort splats only every N frames")]
         public int m_SortNthFrame = 1;
+        [Tooltip("When in VR, sort splats separately for each eye. This increases accuracy but reduces performance.")]
+        public bool m_SortPerEye = false;
 
         public RenderMode m_RenderMode = RenderMode.Splats;
         [Range(1.0f,15.0f)] public float m_PointDisplaySize = 3.0f;

--- a/package/Runtime/GaussianSplatRenderer.cs
+++ b/package/Runtime/GaussianSplatRenderer.cs
@@ -749,7 +749,8 @@ namespace GaussianSplatting.Runtime
 
             // sort the splats
             EnsureSorterAndRegister();
-            m_Sorter.Dispatch(cmd, m_SorterArgs);
+            if (m_Sorter.Valid)
+                m_Sorter.Dispatch(cmd, m_SorterArgs);
             cmd.EndSample(s_ProfSort);
         }
 

--- a/package/Runtime/GaussianSplatURPFeature.cs
+++ b/package/Runtime/GaussianSplatURPFeature.cs
@@ -47,7 +47,8 @@ namespace GaussianSplatting.Runtime
 
                 bool isStereo = XRSettings.enabled && cameraData.camera.stereoEnabled && 
                                 (XRSettings.stereoRenderingMode == XRSettings.StereoRenderingMode.SinglePassInstanced || 
-                                 XRSettings.stereoRenderingMode == XRSettings.StereoRenderingMode.SinglePassMultiview);
+                                 XRSettings.stereoRenderingMode == XRSettings.StereoRenderingMode.SinglePassMultiview) &&
+                                !Application.isEditor;
                 RenderTextureDescriptor rtDesc = isStereo? XRSettings.eyeTextureDesc: cameraData.cameraTargetDescriptor;
                 rtDesc.depthBufferBits = 0;
                 rtDesc.msaaSamples = 1;

--- a/package/Runtime/GaussianSplatURPFeature.cs
+++ b/package/Runtime/GaussianSplatURPFeature.cs
@@ -52,13 +52,6 @@ namespace GaussianSplatting.Runtime
                 rtDesc.depthBufferBits = 0;
                 rtDesc.msaaSamples = 1;
                 rtDesc.graphicsFormat = GraphicsFormat.R16G16B16A16_SFloat;
-                Debug.Log($"isStereo: {isStereo}");
-                Debug.Log($"Dimension: {rtDesc.dimension}");
-                Debug.Log($"Volume: {rtDesc.volumeDepth}");
-                Debug.Log($"stereoRenderingMode: {XRSettings.stereoRenderingMode}");
-                TextureDesc desc = resourceData.activeColorTexture.GetDescriptor(renderGraph);
-                Debug.Log($"xrReady: {desc.dimension}");
-                Debug.Log($"rtDesc vrUsage: {rtDesc.vrUsage}");
                 
                 // Create render texture
                 var gaussianSplatRT = UniversalRenderer.CreateRenderGraphTexture(renderGraph, rtDesc, GaussianSplatRTName, true);
@@ -110,7 +103,7 @@ namespace GaussianSplatting.Runtime
                     }
                     else
                     {
-                        // Legacy single-eye rendering for backward compatibility
+                        // Single-eye rendering
                         commandBuffer.SetGlobalTexture(s_gaussianSplatRT, data.GaussianSplatRT);
                         CoreUtils.SetRenderTarget(commandBuffer, data.GaussianSplatRT, data.SourceDepth, ClearFlag.Color, Color.clear);
                         Material matComposite = GaussianSplatRenderSystem.instance.SortAndRenderSplats(data.CameraData.camera, commandBuffer);

--- a/package/Runtime/GaussianSplatURPFeature.cs
+++ b/package/Runtime/GaussianSplatURPFeature.cs
@@ -99,6 +99,10 @@ namespace GaussianSplatting.Runtime
                             // Prepare the splats once - sort them and calculate view data
                             var renderData = GaussianSplatRenderSystem.instance.PrepareSplats(data.CameraData.camera, commandBuffer);
                             
+                            // [Quest3] Workaround for stereo rendering. Unity is not able to correctly set unity_stereoEyeIndex when drawing to
+                            // a render texture array, so we need to do it manually. Also, we need to draw the same material twice,
+                            // once for each eye. TODO: Revisit this when Unity fixes the issue.
+
                             // Render to left eye
                             CoreUtils.SetRenderTarget(commandBuffer, data.GaussianSplatRT, ClearFlag.Color, Color.clear, 0, CubemapFace.Unknown, 0);
                             GaussianSplatRenderSystem.instance.RenderPreparedSplats(commandBuffer, 0);
@@ -112,7 +116,10 @@ namespace GaussianSplatting.Runtime
                         // Composite to the final target
                         commandBuffer.BeginSample(GaussianSplatRenderSystem.s_ProfCompose);
                         matComposite.SetTexture(s_gaussianSplatRT, data.GaussianSplatRT);
-                        
+
+                        // [Quest3] Workaround for stereo rendering. Unity is not able to correctly set unity_stereoEyeIndex when drawing to
+                        // a render texture array, so we need to do it manually. Also, we need to draw the same material twice,
+                        // once for each eye. TODO: Revisit this when Unity fixes the issue.
                         commandBuffer.SetRenderTarget(data.SourceTexture, 0, CubemapFace.Unknown, 0);
                         commandBuffer.SetGlobalInt("_CustomStereoEyeIndex", 0); // emulate left
                         commandBuffer.DrawProcedural(Matrix4x4.identity, matComposite, 0, MeshTopology.Triangles, 3, 1);

--- a/package/Runtime/GaussianSplatURPFeature.cs
+++ b/package/Runtime/GaussianSplatURPFeature.cs
@@ -111,7 +111,6 @@ namespace GaussianSplatting.Runtime
 
                         // Composite to the final target
                         commandBuffer.BeginSample(GaussianSplatRenderSystem.s_ProfCompose);
-                        commandBuffer.SetGlobalTexture(s_gaussianSplatRT, data.GaussianSplatRT);
                         matComposite.SetTexture(s_gaussianSplatRT, data.GaussianSplatRT);
                         
                         commandBuffer.SetRenderTarget(data.SourceTexture, 0, CubemapFace.Unknown, 0);

--- a/package/Runtime/GaussianSplatURPFeature.cs
+++ b/package/Runtime/GaussianSplatURPFeature.cs
@@ -49,7 +49,9 @@ namespace GaussianSplatting.Runtime
                                 (XRSettings.stereoRenderingMode == XRSettings.StereoRenderingMode.SinglePassInstanced || 
                                  XRSettings.stereoRenderingMode == XRSettings.StereoRenderingMode.SinglePassMultiview) &&
                                 !Application.isEditor;
-                RenderTextureDescriptor rtDesc = isStereo? XRSettings.eyeTextureDesc: cameraData.cameraTargetDescriptor;
+                // Always use cameraTargetDescriptor — it matches the actual depth buffer size (including render scale).
+                // XRSettings.eyeTextureDesc returns the unscaled XR eye texture and causes dimension mismatches.
+                RenderTextureDescriptor rtDesc = cameraData.cameraTargetDescriptor;
                 rtDesc.depthBufferBits = 0;
                 rtDesc.msaaSamples = 1;
                 rtDesc.graphicsFormat = GraphicsFormat.R16G16B16A16_SFloat;
@@ -159,6 +161,10 @@ namespace GaussianSplatting.Runtime
         public override void OnCameraPreCull(ScriptableRenderer renderer, in CameraData cameraData)
         {
             m_HasCamera = false;
+            // Skip cameras that render to a custom RenderTexture (e.g. OVROverlayCanvas cameras).
+            // Splats should only composite into the main XR display camera.
+            if (cameraData.camera.targetTexture != null)
+                return;
             var system = GaussianSplatRenderSystem.instance;
             if (!system.GatherSplatsForCamera(cameraData.camera))
                 return;

--- a/package/Runtime/GaussianSplatURPFeature.cs
+++ b/package/Runtime/GaussianSplatURPFeature.cs
@@ -45,10 +45,13 @@ namespace GaussianSplatting.Runtime
                 var cameraData = frameData.Get<UniversalCameraData>();
                 var resourceData = frameData.Get<UniversalResourceData>();
 
+                // isStereo requires the actual render target to be a Tex2DArray (main XR swapchain).
+                // OVROverlayCanvas and other stereo-enabled-but-2D cameras must take the non-stereo path.
                 bool isStereo = XRSettings.enabled && cameraData.camera.stereoEnabled && 
                                 (XRSettings.stereoRenderingMode == XRSettings.StereoRenderingMode.SinglePassInstanced || 
                                  XRSettings.stereoRenderingMode == XRSettings.StereoRenderingMode.SinglePassMultiview) &&
-                                !Application.isEditor;
+                                !Application.isEditor &&
+                                cameraData.cameraTargetDescriptor.dimension == TextureDimension.Tex2DArray;
                 // Always use cameraTargetDescriptor — it matches the actual depth buffer size (including render scale).
                 // XRSettings.eyeTextureDesc returns the unscaled XR eye texture and causes dimension mismatches.
                 RenderTextureDescriptor rtDesc = cameraData.cameraTargetDescriptor;
@@ -161,10 +164,6 @@ namespace GaussianSplatting.Runtime
         public override void OnCameraPreCull(ScriptableRenderer renderer, in CameraData cameraData)
         {
             m_HasCamera = false;
-            // Skip cameras that render to a custom RenderTexture (e.g. OVROverlayCanvas cameras).
-            // Splats should only composite into the main XR display camera.
-            if (cameraData.camera.targetTexture != null)
-                return;
             var system = GaussianSplatRenderSystem.instance;
             if (!system.GatherSplatsForCamera(cameraData.camera))
                 return;

--- a/package/Shaders/GaussianComposite.shader
+++ b/package/Shaders/GaussianComposite.shader
@@ -15,26 +15,70 @@ CGPROGRAM
 #pragma fragment frag
 #pragma require compute
 #pragma use_dxc
+#pragma require 2darray
+#pragma multi_compile_instancing
+#pragma require instancing
+
+// Enable proper multi-compile support for all stereo rendering modes
+#pragma multi_compile_local _ UNITY_SINGLE_PASS_STEREO STEREO_INSTANCING_ON STEREO_MULTIVIEW_ON
+
 #include "UnityCG.cginc"
 
 struct v2f
 {
     float4 vertex : SV_POSITION;
+    float2 uv : TEXCOORD0;
 };
 
-v2f vert (uint vtxID : SV_VertexID)
+struct appdata
+{
+    float4 vertex : POSITION;
+    float2 uv : TEXCOORD0;
+    uint vtxID : SV_VertexID;
+};
+
+v2f vert (appdata v)
 {
     v2f o;
+    uint vtxID = v.vtxID;
+    
     float2 quadPos = float2(vtxID&1, (vtxID>>1)&1) * 4.0 - 1.0;
-	o.vertex = float4(quadPos, 1, 1);
+    o.vertex = UnityObjectToClipPos(float4(quadPos, 1, 1));
+
+    o.uv = float2(vtxID&1, (vtxID>>1)&1);
     return o;
 }
 
+// Separate textures for left and right eyes
+#if defined(UNITY_SINGLE_PASS_STEREO) || defined(STEREO_INSTANCING_ON) || defined(STEREO_MULTIVIEW_ON)
+UNITY_DECLARE_TEX2DARRAY(_GaussianSplatRT);
+#else
 Texture2D _GaussianSplatRT;
+#endif
 
+int _CustomStereoEyeIndex;
 half4 frag (v2f i) : SV_Target
 {
-    half4 col = _GaussianSplatRT.Load(int3(i.vertex.xy, 0));
+    uint eyeIndex = _CustomStereoEyeIndex;
+    // return float4(eyeIndex == 0 ? 1 : 0, 0, eyeIndex == 1 ? 1 : 0, 1); // Red = left, Blue = right
+    
+    // Normalize the pixel coordinates to [0,1] range
+    float2 normalizedUV = float2(i.vertex.x / _ScreenParams.x, i.vertex.y / _ScreenParams.y);
+    
+#if 1
+    half4 col1, col2, col;
+    
+    // // Check if using separate eye textures
+    #if defined(UNITY_SINGLE_PASS_STEREO) || defined(STEREO_INSTANCING_ON) || defined(STEREO_MULTIVIEW_ON)
+        col1 = UNITY_SAMPLE_TEX2DARRAY(_GaussianSplatRT, float3(normalizedUV, 0));
+        col2 = UNITY_SAMPLE_TEX2DARRAY(_GaussianSplatRT, float3(normalizedUV, 1));
+        col = col2 * eyeIndex + col1 * (1 - eyeIndex);
+    #else
+        // Fallback to legacy single-texture approach for backward compatibility
+        col = _GaussianSplatRT.Load(int3(i.vertex.xy, 0));
+    #endif
+#endif
+
     col.rgb = GammaToLinearSpace(col.rgb);
     col.a = saturate(col.a * 1.5);
     return col;

--- a/package/Shaders/GaussianComposite.shader
+++ b/package/Shaders/GaussianComposite.shader
@@ -16,8 +16,6 @@ CGPROGRAM
 #pragma require compute
 #pragma use_dxc
 #pragma require 2darray
-#pragma multi_compile_instancing
-#pragma require instancing
 
 // Enable proper multi-compile support for all stereo rendering modes
 #pragma multi_compile_local _ UNITY_SINGLE_PASS_STEREO STEREO_INSTANCING_ON STEREO_MULTIVIEW_ON
@@ -44,8 +42,6 @@ v2f vert (appdata v)
     
     float2 quadPos = float2(vtxID&1, (vtxID>>1)&1) * 4.0 - 1.0;
     o.vertex = UnityObjectToClipPos(float4(quadPos, 1, 1));
-
-    o.uv = float2(vtxID&1, (vtxID>>1)&1);
     return o;
 }
 
@@ -60,24 +56,17 @@ int _CustomStereoEyeIndex;
 half4 frag (v2f i) : SV_Target
 {
     uint eyeIndex = _CustomStereoEyeIndex;
-    // return float4(eyeIndex == 0 ? 1 : 0, 0, eyeIndex == 1 ? 1 : 0, 1); // Red = left, Blue = right
-    
     // Normalize the pixel coordinates to [0,1] range
     float2 normalizedUV = float2(i.vertex.x / _ScreenParams.x, i.vertex.y / _ScreenParams.y);
+    half4 col;
     
-#if 1
-    half4 col1, col2, col;
-    
-    // // Check if using separate eye textures
+    // Check if using separate eye textures
     #if defined(UNITY_SINGLE_PASS_STEREO) || defined(STEREO_INSTANCING_ON) || defined(STEREO_MULTIVIEW_ON)
-        col1 = UNITY_SAMPLE_TEX2DARRAY(_GaussianSplatRT, float3(normalizedUV, 0));
-        col2 = UNITY_SAMPLE_TEX2DARRAY(_GaussianSplatRT, float3(normalizedUV, 1));
-        col = col2 * eyeIndex + col1 * (1 - eyeIndex);
+        col = UNITY_SAMPLE_TEX2DARRAY(_GaussianSplatRT, float3(normalizedUV, eyeIndex));
     #else
         // Fallback to legacy single-texture approach for backward compatibility
         col = _GaussianSplatRT.Load(int3(i.vertex.xy, 0));
     #endif
-#endif
 
     col.rgb = GammaToLinearSpace(col.rgb);
     col.a = saturate(col.a * 1.5);

--- a/package/Shaders/GaussianComposite.shader
+++ b/package/Shaders/GaussianComposite.shader
@@ -38,7 +38,7 @@ v2f vert (uint vtxID : SV_VertexID)
     v2f o;
     
     float2 quadPos = float2(vtxID&1, (vtxID>>1)&1) * 4.0 - 1.0;
-    o.vertex = UnityObjectToClipPos(float4(quadPos, 1, 1));
+    o.vertex = float4(quadPos, 1, 1);
     return o;
 }
 

--- a/package/Shaders/RenderGaussianSplats.shader
+++ b/package/Shaders/RenderGaussianSplats.shader
@@ -35,10 +35,10 @@ uint _EyeIndex;
 uint _IsStereo;
 v2f vert (uint vtxID : SV_VertexID, uint instID : SV_InstanceID)
 {
-    v2f o = (v2f)0;
-    instID = _OrderBuffer[instID];
-    uint eyeIndex = _EyeIndex;
-    uint viewIndex = _IsStereo ? instID * 2 + eyeIndex : instID;
+	v2f o = (v2f)0;
+	instID = _OrderBuffer[instID];
+	uint eyeIndex = _EyeIndex;
+	uint viewIndex = _IsStereo ? instID * 2 + eyeIndex : instID;
 	SplatViewData view = _SplatViewData[viewIndex];
 	float4 centerClipPos = view.pos;
 	bool behindCam = centerClipPos.w <= 0;

--- a/package/Shaders/RenderGaussianSplats.shader
+++ b/package/Shaders/RenderGaussianSplats.shader
@@ -31,12 +31,15 @@ struct v2f
 StructuredBuffer<SplatViewData> _SplatViewData;
 ByteAddressBuffer _SplatSelectedBits;
 uint _SplatBitsValid;
-
+uint _EyeIndex;
+uint _IsStereo;
 v2f vert (uint vtxID : SV_VertexID, uint instID : SV_InstanceID)
 {
     v2f o = (v2f)0;
     instID = _OrderBuffer[instID];
-	SplatViewData view = _SplatViewData[instID];
+    uint eyeIndex = _EyeIndex;
+    uint viewIndex = _IsStereo ? instID * 2 + eyeIndex : instID;
+	SplatViewData view = _SplatViewData[viewIndex];
 	float4 centerClipPos = view.pos;
 	bool behindCam = centerClipPos.w <= 0;
 	if (behindCam)

--- a/package/Shaders/SplatUtilities.compute
+++ b/package/Shaders/SplatUtilities.compute
@@ -81,13 +81,19 @@ void CSCalcDistances (uint3 id : SV_DispatchThreadID)
     _SplatSortDistances[idx] = FloatToSortableUint(pos.z);
 }
 
+cbuffer StereoMatrices
+{
+    float4x4 _ViewProjMatrixLeft;
+    float4x4 _ViewProjMatrixRight;
+};
+
 RWStructuredBuffer<SplatViewData> _SplatViewData;
 
 float _SplatScale;
 float _SplatOpacityScale;
 uint _SHOrder;
 uint _SHOnly;
-
+uint _IsStereo;
 uint _SplatCutoutsCount;
 
 #define SPLAT_CUTOUT_TYPE_ELLIPSOID 0
@@ -186,40 +192,18 @@ bool IsSplatCut(float3 pos)
     return finalCut;
 }
 
-[numthreads(GROUP_SIZE,1,1)]
-void CSCalcViewData (uint3 id : SV_DispatchThreadID)
+SplatViewData CalculateEyeViewData(SplatData splat, float3 centerWorldPos, float4x4 viewProjMatrix, bool isDeleted, bool isCut, float splatScale, half opacityScale)
 {
-    uint idx = id.x;
-    if (idx >= _SplatCount)
-        return;
-
-    SplatData splat = LoadSplatData(idx);
     SplatViewData view = (SplatViewData)0;
     
-    float3 centerWorldPos = mul(_MatrixObjectToWorld, float4(splat.pos,1)).xyz;
-    float4 centerClipPos = mul(UNITY_MATRIX_VP, float4(centerWorldPos, 1));
-    half opacityScale = _SplatOpacityScale;
-    float splatScale = _SplatScale;
-
-    // deleted?
-    if (_SplatBitsValid)
-    {
-        uint wordIdx = idx / 32;
-        uint bitIdx = idx & 31;
-        uint wordVal = _SplatDeletedBits.Load(wordIdx * 4);
-        if (wordVal & (1 << bitIdx))
-        {
-            centerClipPos.w = 0;
-        }
-    }
-
-    // cutouts
-    if (IsSplatCut(splat.pos))
+    // Calculate projection
+    float4 centerClipPos = mul(viewProjMatrix, float4(centerWorldPos, 1));
+    if (isDeleted || isCut)
     {
         centerClipPos.w = 0;
     }
-
     view.pos = centerClipPos;
+    
     bool behindCam = centerClipPos.w <= 0;
     if (!behindCam)
     {
@@ -248,7 +232,53 @@ void CSCalcViewData (uint3 id : SV_DispatchThreadID)
         view.color.y = (f32tof16(col.b) << 16) | f32tof16(col.a);
     }
     
-    _SplatViewData[idx] = view;
+    return view;
+}
+
+[numthreads(GROUP_SIZE,1,1)]
+void CSCalcViewData (uint3 id : SV_DispatchThreadID)
+{
+    uint idx = id.x;
+    if (idx >= _SplatCount)
+        return;
+
+    SplatData splat = LoadSplatData(idx);
+    
+    // Transform to world space
+    float3 centerWorldPos = mul(_MatrixObjectToWorld, float4(splat.pos,1)).xyz;
+    float splatScale = _SplatScale;
+    half opacityScale = _SplatOpacityScale;
+
+    // Check if deleted
+    bool isDeleted = false;
+    if (_SplatBitsValid)
+    {
+        uint wordIdx = idx / 32;
+        uint bitIdx = idx & 31;
+        uint wordVal = _SplatDeletedBits.Load(wordIdx * 4);
+        if (wordVal & (1 << bitIdx))
+        {
+            isDeleted = true;
+        }
+    }
+
+    // Check if cut
+    bool isCut = IsSplatCut(splat.pos);
+
+    if (_IsStereo)
+    {
+        // Calculate view data for both eyes
+        SplatViewData viewLeft = CalculateEyeViewData(splat, centerWorldPos, _ViewProjMatrixLeft, isDeleted, isCut, splatScale, opacityScale);
+        SplatViewData viewRight = CalculateEyeViewData(splat, centerWorldPos, _ViewProjMatrixRight, isDeleted, isCut, splatScale, opacityScale);
+        
+        // Store both views
+        _SplatViewData[idx * 2] = viewLeft;
+        _SplatViewData[idx * 2 + 1] = viewRight;
+    }
+    else
+    {
+        _SplatViewData[idx] = CalculateEyeViewData(splat, centerWorldPos, UNITY_MATRIX_VP, isDeleted, isCut, splatScale, opacityScale);
+    }
 }
 
 


### PR DESCRIPTION
Support for Single Pass Instanced/Multiview rendering mode. Tested on Quest3

1. Use correct projection matrices per eye to calculate per eye view data in single shader call
2. Use EyeIndex to index into view data in RenderGaussianSplats shader for drawing correct eye texture for Splat
3. Use single prepatation step but separate render calls for Splat and composite in URP based on texture slices of 2darray texture
4. Use Texture 2dArray in GaussianComposite shader to draw the per eye texture correctly based on pass eye index

Also, ensured that non-VR mode and Multipass continue to work correctly

Not resolved in this PR:
1. HDRP for single pass instanced. We don't often use this pipeline in VR so low priority
2. Debug points and boxes shaders