### PR TITLE
use one tri instead of two for each splat

### DIFF
--- a/package/Runtime/GaussianSplatRenderer.cs
+++ b/package/Runtime/GaussianSplatRenderer.cs
@@ -153,17 +153,21 @@ namespace GaussianSplatting.Runtime
                 cmb.EndSample(s_ProfCalcView);
 
                 // draw
-                int indexCount = 6;
                 int instanceCount = gs.splatCount;
                 MeshTopology topology = MeshTopology.Triangles;
-                if (gs.m_RenderMode is GaussianSplatRenderer.RenderMode.DebugBoxes or GaussianSplatRenderer.RenderMode.DebugChunkBounds)
-                    indexCount = 36;
-                if (gs.m_RenderMode == GaussianSplatRenderer.RenderMode.DebugChunkBounds)
-                    instanceCount = gs.m_GpuChunksValid ? gs.m_GpuChunks.count : 0;
+                if (gs.m_RenderMode is GaussianSplatRenderer.RenderMode.DebugBoxes or GaussianSplatRenderer.RenderMode.DebugChunkBounds) {
+                    if (gs.m_RenderMode == GaussianSplatRenderer.RenderMode.DebugChunkBounds)
+                        instanceCount = gs.m_GpuChunksValid ? gs.m_GpuChunks.count : 0;
 
-                cmb.BeginSample(s_ProfDraw);
-                cmb.DrawProcedural(gs.m_GpuIndexBuffer, matrix, displayMat, 0, topology, indexCount, instanceCount, mpb);
-                cmb.EndSample(s_ProfDraw);
+                    cmb.BeginSample(s_ProfDraw);
+                    cmb.DrawProcedural(gs.m_GpuIndexBuffer, matrix, displayMat, 0, topology, 36, instanceCount, mpb);
+                    cmb.EndSample(s_ProfDraw);
+                } else {
+                    cmb.BeginSample(s_ProfDraw);
+                    cmb.DrawProcedural(matrix, displayMat, 0, topology, 3, instanceCount, mpb);
+                    cmb.EndSample(s_ProfDraw);
+                }
+
             }
             return matComposite;
         }

--- a/package/Shaders/RenderGaussianSplats.shader
+++ b/package/Shaders/RenderGaussianSplats.shader
@@ -10,7 +10,7 @@ Shader "Gaussian Splatting/Render Splats"
             ZWrite Off
             Blend OneMinusDstAlpha One
             Cull Off
-            
+
 CGPROGRAM
 #pragma vertex vert
 #pragma fragment frag
@@ -36,70 +36,75 @@ v2f vert (uint vtxID : SV_VertexID, uint instID : SV_InstanceID)
 {
     v2f o = (v2f)0;
     instID = _OrderBuffer[instID];
-	SplatViewData view = _SplatViewData[instID];
-	float4 centerClipPos = view.pos;
-	bool behindCam = centerClipPos.w <= 0;
-	if (behindCam)
-	{
-		o.vertex = asfloat(0x7fc00000); // NaN discards the primitive
-	}
-	else
-	{
-		o.col.r = f16tof32(view.color.x >> 16);
-		o.col.g = f16tof32(view.color.x);
-		o.col.b = f16tof32(view.color.y >> 16);
-		o.col.a = f16tof32(view.color.y);
+    SplatViewData view = _SplatViewData[instID];
+    float4 centerClipPos = view.pos;
+    bool behindCam = centerClipPos.w <= 0;
+    if (behindCam)
+    {
+        o.vertex = asfloat(0x7fc00000); // NaN discards the primitive
+    }
+    else
+    {
+        o.col.r = f16tof32(view.color.x >> 16);
+        o.col.g = f16tof32(view.color.x);
+        o.col.b = f16tof32(view.color.y >> 16);
+        o.col.a = f16tof32(view.color.y);
 
-		uint idx = vtxID;
-		float2 quadPos = float2(idx&1, (idx>>1)&1) * 2.0 - 1.0;
-		quadPos *= 2;
+        float2 quadPos;
+        if (vtxID == 0) {
+            quadPos = float2(sqrt(3), -1);
+        } else if (vtxID == 1) {
+            quadPos = float2(-sqrt(3), -1);
+        } else {
+            quadPos = float2(0, 2);
+        }
+        quadPos *= 2.0;
+        o.pos = quadPos;
 
-		o.pos = quadPos;
+        float2 deltaScreenPos = (quadPos.x * view.axis1 + quadPos.y * view.axis2) * 2 / _ScreenParams.xy;
+        o.vertex = centerClipPos;
+        o.vertex.xy += deltaScreenPos * centerClipPos.w;
 
-		float2 deltaScreenPos = (quadPos.x * view.axis1 + quadPos.y * view.axis2) * 2 / _ScreenParams.xy;
-		o.vertex = centerClipPos;
-		o.vertex.xy += deltaScreenPos * centerClipPos.w;
-
-		// is this splat selected?
-		if (_SplatBitsValid)
-		{
-			uint wordIdx = instID / 32;
-			uint bitIdx = instID & 31;
-			uint selVal = _SplatSelectedBits.Load(wordIdx * 4);
-			if (selVal & (1 << bitIdx))
-			{
-				o.col.a = -1;				
-			}
-		}
-	}
-	FlipProjectionIfBackbuffer(o.vertex);
+        // is this splat selected?
+        if (_SplatBitsValid)
+        {
+            uint wordIdx = instID / 32;
+            uint bitIdx = instID & 31;
+            uint selVal = _SplatSelectedBits.Load(wordIdx * 4);
+            if (selVal & (1 << bitIdx))
+            {
+                o.col.a = -1;
+            }
+        }
+    }
+    FlipProjectionIfBackbuffer(o.vertex);
     return o;
 }
 
 half4 frag (v2f i) : SV_Target
 {
-	float power = -dot(i.pos, i.pos);
-	half alpha = exp(power);
-	if (i.col.a >= 0)
-	{
-		alpha = saturate(alpha * i.col.a);
-	}
-	else
-	{
-		// "selected" splat: magenta outline, increase opacity, magenta tint
-		half3 selectedColor = half3(1,0,1);
-		if (alpha > 7.0/255.0)
-		{
-			if (alpha < 10.0/255.0)
-			{
-				alpha = 1;
-				i.col.rgb = selectedColor;
-			}
-			alpha = saturate(alpha + 0.3);
-		}
-		i.col.rgb = lerp(i.col.rgb, selectedColor, 0.5);
-	}
-	
+    float power = -dot(i.pos, i.pos);
+    half alpha = exp(power);
+    if (i.col.a >= 0)
+    {
+        alpha = saturate(alpha * i.col.a);
+    }
+    else
+    {
+        // "selected" splat: magenta outline, increase opacity, magenta tint
+        half3 selectedColor = half3(1,0,1);
+        if (alpha > 7.0/255.0)
+        {
+            if (alpha < 10.0/255.0)
+            {
+                alpha = 1;
+                i.col.rgb = selectedColor;
+            }
+            alpha = saturate(alpha + 0.3);
+        }
+        i.col.rgb = lerp(i.col.rgb, selectedColor, 0.5);
+    }
+    
     if (alpha < 1.0/255.0)
         discard;
 


### PR DESCRIPTION
![demo](https://github.com/user-attachments/assets/c6b0ad83-15e8-4d96-a3e8-f9a154eb2dcb)

You only need one tri to render each splat, from my benchmarking this is in the range of 3-7% faster.

The same 99% of the splat is covered but it gives the pixel shader `sqrt(3)` more empty area to render.
The triangle covering the splat is optimal.

I would argue that it is more pleasant for users that number of splats == num of tris.

![image](https://github.com/user-attachments/assets/e7145b7d-a346-46a4-a441-2f786993a74a)
