### PR TITLE
Fix blending of Gaussians with external objects

### DIFF
--- a/package/Shaders/GaussianComposite.shader
+++ b/package/Shaders/GaussianComposite.shader
@@ -35,7 +35,6 @@ Texture2D _GaussianSplatRT;
 half4 frag (v2f i) : SV_Target
 {
     half4 col = _GaussianSplatRT.Load(int3(i.vertex.xy, 0));
-    col.a = saturate(col.a);
     return float4(GammaToLinearSpace(col.rgb/col.a),col.a);
 }
 ENDCG

--- a/package/Shaders/GaussianComposite.shader
+++ b/package/Shaders/GaussianComposite.shader
@@ -35,9 +35,8 @@ Texture2D _GaussianSplatRT;
 half4 frag (v2f i) : SV_Target
 {
     half4 col = _GaussianSplatRT.Load(int3(i.vertex.xy, 0));
-    col.rgb = GammaToLinearSpace(col.rgb);
-    col.a = saturate(col.a * 1.5);
-    return col;
+    col.a = saturate(col.a);
+    return float4(GammaToLinearSpace(col.rgb/col.a),col.a);
 }
 ENDCG
         }


### PR DESCRIPTION
Removes the dark band around Gaussian Splat models against other objects.
Tested in Built-In render pipeline, URP, and HDRP.
<img width="947" height="456" alt="Screenshot from 2025-07-15 11-04-33" src="https://github.com/user-attachments/assets/ddafce17-7e7c-4c66-91aa-d0fd1939ba90" />
<img width="947" height="468" alt="Screenshot from 2025-07-15 11-06-46" src="https://github.com/user-attachments/assets/a9fb88c7-4bed-402e-9fba-72e1c6ae5755" />

The opacity around the edges can also be increased (without darkening edges) by changing
`return float4(GammaToLinearSpace(col.rgb/col.a),col.a);`
to
`return float4(GammaToLinearSpace(col.rgb/col.a),saturate(col.a*1.5));`
but I'm unsure exactly what the purpose of this was before.