### PR TITLE
fix(shader): Fixes non-splat black background transparency in renderer

### DIFF
--- a/package/Shaders/GaussianComposite.shader
+++ b/package/Shaders/GaussianComposite.shader
@@ -35,7 +35,8 @@ Texture2D _GaussianSplatRT;
 half4 frag (v2f i) : SV_Target
 {
     half4 col = _GaussianSplatRT.Load(int3(i.vertex.xy, 0));
-    return float4(GammaToLinearSpace(col.rgb/col.a),col.a);
+    col.rgb = GammaToLinearSpace(col.a != 0 ? col.rgb/col.a : col.rgb);
+    return float4(col.rgb, col.a);
 }
 ENDCG
         }


### PR DESCRIPTION
Fixes black background transparency layer when loading a splat. Issue caused in [4822f2e](https://github.com/aras-p/UnityGaussianSplatting/commit/4822f2e2e411bba9508c9c3d60027c14f078ab6b). Credit to @EdwardLu2018.
