### PR TITLE
Prevent creating splat resources multiple times

### DIFF
--- a/package/Runtime/GaussianSplatRenderer.cs
+++ b/package/Runtime/GaussianSplatRenderer.cs
@@ -474,14 +474,23 @@ namespace GaussianSplatting.Runtime
 
         public void OnEnable()
         {
-            m_FrameCounter = 0;
-            if (!resourcesAreSetUp)
-                return;
+            var curHash = m_Asset ? m_Asset.dataHash : new Hash128();
 
-            EnsureMaterials();
-            EnsureSorterAndRegister();
+            //OnEnable will run multiple times when entering play mode from the editor
+            if (m_PrevAsset != m_Asset || m_PrevHash != curHash)
+            {
+                m_PrevAsset = m_Asset;
+                m_PrevHash = curHash;
 
-            CreateResourcesForAsset();
+                m_FrameCounter = 0;
+                if (!resourcesAreSetUp)
+                    return;
+                
+                EnsureMaterials();
+                EnsureSorterAndRegister();
+
+                CreateResourcesForAsset();
+            }
         }
 
         void SetAssetDataOnCS(CommandBuffer cmb, KernelIndices kernel)

--- a/package/Runtime/GaussianSplatRenderer.cs
+++ b/package/Runtime/GaussianSplatRenderer.cs
@@ -479,13 +479,13 @@ namespace GaussianSplatting.Runtime
             //OnEnable will run multiple times when entering play mode from the editor
             if (m_PrevAsset != m_Asset || m_PrevHash != curHash)
             {
-                m_PrevAsset = m_Asset;
-                m_PrevHash = curHash;
-
                 m_FrameCounter = 0;
                 if (!resourcesAreSetUp)
                     return;
                 
+                m_PrevAsset = m_Asset;
+                m_PrevHash = curHash;
+
                 EnsureMaterials();
                 EnsureSorterAndRegister();
 


### PR DESCRIPTION
This fixes an issue where the CreateResourcesForAsset() function would be called three times with identical assets when starting the project from the editor.

When starting a unity project from the editor, when a component also runs in edit mode, the OnEnable function will be called multiple times. I think that this is a bug in unity (I don't know why this behavior would be expected) but we can prevent resources from being created multiple times here by checking the hash of the asset, similarly to how this is done in the `Update(` function.

Additionally, by setting the `m_PrevAsset` and `m_PrevHash` variables here, this fixes a problem where the same resources would be loaded again when the Update function runs, as the hashes would not have been initialized.