### PR TITLE
Fix Isometric Projection

### DIFF
--- a/package/Shaders/GaussianSplatting.hlsl
+++ b/package/Shaders/GaussianSplatting.hlsl
@@ -69,11 +69,22 @@ float3 CalcCovariance2D(float3 worldPos, float3 cov3d0, float3 cov3d1, float4x4 
 
     float focal = screenParams.x * matrixP._m00 / 2;
 
-    float3x3 J = float3x3(
-        focal / viewPos.z, 0, -(focal * viewPos.x) / (viewPos.z * viewPos.z),
-        0, focal / viewPos.z, -(focal * viewPos.y) / (viewPos.z * viewPos.z),
-        0, 0, 0
-    );
+    bool isIsometric = matrixP._m33 == 1.0;
+    float3x3 J;
+    if (isIsometric) {
+      J = float3x3(
+          focal, 0, 0,
+          0, focal, 0,
+          0, 0, 0
+      );
+    } else {
+      J = float3x3(
+          focal / viewPos.z, 0, -(focal * viewPos.x) / (viewPos.z * viewPos.z),
+          0, focal / viewPos.z, -(focal * viewPos.y) / (viewPos.z * viewPos.z),
+          0, 0, 0
+      );
+    }
+    
     float3x3 W = (float3x3)viewMatrix;
     float3x3 T = mul(J, W);
     float3x3 V = float3x3(


### PR DESCRIPTION
**Important:** If `isIsometric` is `true` when it should be `false` every Gaussian will take up the entire screen and crash Unity.

I am not 100% sure that the `isIsometric` works for all graphics APIs, maybe someone knows a better way to do this.

You could factor `focal` out of both Jacobian matrices and apply it later but then you end up with slightly more multiplications.

<img width="1387" height="772" alt="image" src="https://github.com/user-attachments/assets/a278e922-9dc8-42b8-affb-489309ec0d0b" />


<img width="765" height="726" alt="image" src="https://github.com/user-attachments/assets/6bbd9a8d-3aec-4e1f-a685-2c9e37a98d75" />
