### PR TITLE
Support spherical harmonics < 3 in spz file reader

### DIFF
--- a/package/Editor/Utils/SPZFileReader.cs
+++ b/package/Editor/Utils/SPZFileReader.cs
@@ -159,22 +159,24 @@ namespace GaussianSplatting.Editor.Utils
                 col /= 0.15f;
                 splat.dc0 = GaussianUtils.SH0ToColor(col);
 
+                // Only unpack SH coefficients if they exist in the file
+                // shCoeffs can be 0, 3, 8, or 15 depending on shLevel (0, 1, 2, or 3)
                 int shIdx = index * shCoeffs * 3;
-                splat.sh1 = UnpackSH(shIdx); shIdx += 3;
-                splat.sh2 = UnpackSH(shIdx); shIdx += 3;
-                splat.sh3 = UnpackSH(shIdx); shIdx += 3;
-                splat.sh4 = UnpackSH(shIdx); shIdx += 3;
-                splat.sh5 = UnpackSH(shIdx); shIdx += 3;
-                splat.sh6 = UnpackSH(shIdx); shIdx += 3;
-                splat.sh7 = UnpackSH(shIdx); shIdx += 3;
-                splat.sh8 = UnpackSH(shIdx); shIdx += 3;
-                splat.sh9 = UnpackSH(shIdx); shIdx += 3;
-                splat.shA = UnpackSH(shIdx); shIdx += 3;
-                splat.shB = UnpackSH(shIdx); shIdx += 3;
-                splat.shC = UnpackSH(shIdx); shIdx += 3;
-                splat.shD = UnpackSH(shIdx); shIdx += 3;
-                splat.shE = UnpackSH(shIdx); shIdx += 3;
-                splat.shF = UnpackSH(shIdx); shIdx += 3;
+                if (shCoeffs >= 1) { splat.sh1 = UnpackSH(shIdx); shIdx += 3; }
+                if (shCoeffs >= 2) { splat.sh2 = UnpackSH(shIdx); shIdx += 3; }
+                if (shCoeffs >= 3) { splat.sh3 = UnpackSH(shIdx); shIdx += 3; }
+                if (shCoeffs >= 4) { splat.sh4 = UnpackSH(shIdx); shIdx += 3; }
+                if (shCoeffs >= 5) { splat.sh5 = UnpackSH(shIdx); shIdx += 3; }
+                if (shCoeffs >= 6) { splat.sh6 = UnpackSH(shIdx); shIdx += 3; }
+                if (shCoeffs >= 7) { splat.sh7 = UnpackSH(shIdx); shIdx += 3; }
+                if (shCoeffs >= 8) { splat.sh8 = UnpackSH(shIdx); shIdx += 3; }
+                if (shCoeffs >= 9) { splat.sh9 = UnpackSH(shIdx); shIdx += 3; }
+                if (shCoeffs >= 10) { splat.shA = UnpackSH(shIdx); shIdx += 3; }
+                if (shCoeffs >= 11) { splat.shB = UnpackSH(shIdx); shIdx += 3; }
+                if (shCoeffs >= 12) { splat.shC = UnpackSH(shIdx); shIdx += 3; }
+                if (shCoeffs >= 13) { splat.shD = UnpackSH(shIdx); shIdx += 3; }
+                if (shCoeffs >= 14) { splat.shE = UnpackSH(shIdx); shIdx += 3; }
+                if (shCoeffs >= 15) { splat.shF = UnpackSH(shIdx); shIdx += 3; }
 
                 splats[index] = splat;
             }


### PR DESCRIPTION
spz equivalent of the ply fix in https://github.com/aras-p/UnityGaussianSplatting/pull/200#issue-3412194705 !
some spz splat files do not have the full set of spherical harmonics, this PR allows us to load those files in.
