### PR TITLE
Frustum Culling

### DIFF
--- a/package/Editor/GaussianSplatRendererEditor.cs
+++ b/package/Editor/GaussianSplatRendererEditor.cs
@@ -35,6 +35,8 @@ namespace GaussianSplatting.Editor
         SerializedProperty m_PropShaderDebugPoints;
         SerializedProperty m_PropShaderDebugBoxes;
         SerializedProperty m_PropCSSplatUtilities;
+        SerializedProperty m_PropPrintCulledSplats;
+        SerializedProperty m_PropDebugCullReadbackEveryNFrames;
 
         bool m_ResourcesExpanded = false;
         int m_CameraIndex = 0;
@@ -75,6 +77,8 @@ namespace GaussianSplatting.Editor
             m_PropShaderDebugPoints = serializedObject.FindProperty("m_ShaderDebugPoints");
             m_PropShaderDebugBoxes = serializedObject.FindProperty("m_ShaderDebugBoxes");
             m_PropCSSplatUtilities = serializedObject.FindProperty("m_CSSplatUtilities");
+            m_PropPrintCulledSplats = serializedObject.FindProperty("m_PrintCulledSplats");
+            m_PropDebugCullReadbackEveryNFrames = serializedObject.FindProperty("m_DebugCullReadbackEveryNFrames");
 
             s_AllEditors.Add(this);
         }
@@ -117,6 +121,12 @@ namespace GaussianSplatting.Editor
             EditorGUILayout.PropertyField(m_PropRenderMode);
             if (m_PropRenderMode.intValue is (int)GaussianSplatRenderer.RenderMode.DebugPoints or (int)GaussianSplatRenderer.RenderMode.DebugPointIndices)
                 EditorGUILayout.PropertyField(m_PropPointDisplaySize);
+
+            EditorGUILayout.PropertyField(m_PropPrintCulledSplats);
+            using (new EditorGUI.DisabledScope(!m_PropPrintCulledSplats.boolValue))
+            {
+                EditorGUILayout.PropertyField(m_PropDebugCullReadbackEveryNFrames);
+            }
 
             EditorGUILayout.Space();
             m_ResourcesExpanded = EditorGUILayout.Foldout(m_ResourcesExpanded, "Resources", true, EditorStyles.foldoutHeader);

--- a/package/Runtime/GaussianSplatRenderer.cs
+++ b/package/Runtime/GaussianSplatRenderer.cs
@@ -121,12 +121,6 @@ namespace GaussianSplatting.Runtime
 
                 var mpb = kvp.Item2;
 
-                // sort
-                var matrix = gs.transform.localToWorldMatrix;
-                if (gs.m_FrameCounter % gs.m_SortNthFrame == 0)
-                    gs.SortPoints(cmb, cam, matrix);
-                ++gs.m_FrameCounter;
-
                 // cache view
                 kvp.Item2.Clear();
 
@@ -159,6 +153,12 @@ namespace GaussianSplatting.Runtime
                 cmb.BeginSample(s_ProfCalcView);
                 gs.CalcViewData(cmb, cam);
                 cmb.EndSample(s_ProfCalcView);
+				
+                // sort
+                var matrix = gs.transform.localToWorldMatrix;
+                if (gs.m_FrameCounter % gs.m_SortNthFrame == 0)
+                    gs.SortPoints(cmb, cam, matrix);
+                ++gs.m_FrameCounter;
 
                 // draw
                 MeshTopology topology = MeshTopology.Triangles;

--- a/package/Runtime/GaussianSplatRenderer.cs
+++ b/package/Runtime/GaussianSplatRenderer.cs
@@ -163,22 +163,24 @@ namespace GaussianSplatting.Runtime
                 // draw
                 MeshTopology topology = MeshTopology.Triangles;
 
-                if (gs.m_RenderMode == GaussianSplatRenderer.RenderMode.DebugChunkBounds)
+                if (gs.m_RenderMode != GaussianSplatRenderer.RenderMode.Splats)
                 {
-                    int indexCount = 36;
-                    int instanceCount = gs.m_GpuChunksValid ? gs.m_GpuChunks.count : 0;
+                    int indexCount = gs.m_RenderMode == GaussianSplatRenderer.RenderMode.DebugBoxes ||
+                                     gs.m_RenderMode == GaussianSplatRenderer.RenderMode.DebugChunkBounds ? 36 : 6;
+                    int instanceCount = gs.splatCount;
+
+                    if(gs.m_RenderMode == GaussianSplatRenderer.RenderMode.DebugChunkBounds)
+                        instanceCount = gs.m_GpuChunksValid ? gs.m_GpuChunks.count : 0;
+
+                    cmb.BeginSample(s_ProfDraw);
                     cmb.DrawProcedural(gs.m_GpuIndexBuffer, matrix, displayMat, 0, topology,
                         indexCount, instanceCount, mpb);
+                    cmb.EndSample(s_ProfDraw);
                 }
                 else
                 {
-                    // Indirect args choose quad vs cube
-                    GraphicsBuffer args = gs.m_RenderMode == GaussianSplatRenderer.RenderMode.DebugBoxes
-                        ? gs.drawArgsCube
-                        : gs.drawArgsQuad;
-
                     cmb.BeginSample(s_ProfDraw);
-                    cmb.DrawProceduralIndirect(gs.m_GpuIndexBuffer, matrix, displayMat, 0, topology, args, 0, mpb);
+                    cmb.DrawProceduralIndirect(gs.m_GpuIndexBuffer, matrix, displayMat, 0, topology, gs.drawArgsQuad, 0, mpb);
                     cmb.EndSample(s_ProfDraw);
                 }
             }

--- a/package/Runtime/GaussianSplatRenderer.cs
+++ b/package/Runtime/GaussianSplatRenderer.cs
@@ -153,7 +153,7 @@ namespace GaussianSplatting.Runtime
                 cmb.BeginSample(s_ProfCalcView);
                 gs.CalcViewData(cmb, cam);
                 cmb.EndSample(s_ProfCalcView);
-				
+
                 // sort
                 var matrix = gs.transform.localToWorldMatrix;
                 if (gs.m_FrameCounter % gs.m_SortNthFrame == 0)
@@ -317,8 +317,6 @@ namespace GaussianSplatting.Runtime
 
         //buffers for frustum culling
         GraphicsBuffer m_GpuVisibleKeyCount;
-        int m_LastVisibilityFrame = -1;
-        int m_LastVisibilityCameraId = 0;
 
         //argument buffers for the indirect dispatch/draw commands
         GraphicsBuffer m_GpuArgsDispatchVisible; // 3 uints
@@ -873,13 +871,9 @@ namespace GaussianSplatting.Runtime
 
         void UpdateVisibilityAndIndirectArgs(CommandBuffer cmb, Matrix4x4 localToWorld, Camera cam)
         {
-            // avoid updating twice in the same frame for the same camera (can happen due to m_SortNthFrame)
-            int camId = cam ? cam.GetInstanceID() : 0;
-            int frame = Time.renderedFrameCount;
-            if (m_LastVisibilityFrame == frame && m_LastVisibilityCameraId == camId) return;
-
-            m_LastVisibilityFrame = frame;
-            m_LastVisibilityCameraId = camId;
+            // Skip Culling if the frame is not sorted
+            if(m_FrameCounter % m_SortNthFrame != 0)
+                return;
 
             EnsureCullBuffers(m_SplatCount);
             EnsureIndirectArgsBuffers();
@@ -904,26 +898,6 @@ namespace GaussianSplatting.Runtime
             if (cam.cameraType == CameraType.Preview) return;
 
             int sortCount = m_SplatCount;
-
-            //Frustum culling
-            UpdateVisibilityAndIndirectArgs(cmd, matrix, cam);
-
-            EnsureCullBuffers(m_SplatCount);
-            EnsureIndirectArgsBuffers();
-
-            // running DispatchCullAndBuildVisibleKeys inside UpdateVisibilityAndIndirectArgs is not reliable in edit mode.
-            // Therefore we run it here again.
-            bool editMode = !Application.isPlaying;
-            if (editMode)
-                DispatchCullAndBuildVisibleKeys(cmd, matrix);
-
-            // build indirect args buffers from m_GpuVisibleKeyCount
-            cmd.SetComputeIntParam(m_CSSplatUtilities, Props.SplatCount, m_SplatCount);
-            cmd.SetComputeBufferParam(m_CSSplatUtilities, (int)KernelIndices.BuildIndirectArgs, Props.VisibleKeyCount, m_GpuVisibleKeyCount);
-            cmd.SetComputeBufferParam(m_CSSplatUtilities, (int)KernelIndices.BuildIndirectArgs, Props.ArgsDispatchVisible, m_GpuArgsDispatchVisible);
-            cmd.SetComputeBufferParam(m_CSSplatUtilities, (int)KernelIndices.BuildIndirectArgs, Props.ArgsDrawQuad, m_GpuArgsDrawQuad);
-            cmd.SetComputeBufferParam(m_CSSplatUtilities, (int)KernelIndices.BuildIndirectArgs, Props.ArgsDrawCube, m_GpuArgsDrawCube);
-            cmd.DispatchCompute(m_CSSplatUtilities, (int)KernelIndices.BuildIndirectArgs, 1, 1, 1);
 
             Matrix4x4 worldToCamMatrix = cam.worldToCameraMatrix;
             worldToCamMatrix.m20 *= -1;

--- a/package/Runtime/GaussianSplatRenderer.cs
+++ b/package/Runtime/GaussianSplatRenderer.cs
@@ -949,7 +949,7 @@ namespace GaussianSplatting.Runtime
 
             // sort the splats
             EnsureSorterAndRegister();
-            m_Sorter.DispatchIndirectCount(cmd, m_SorterArgs, m_GpuVisibleKeyCount);
+            m_Sorter.DispatchIndirect(cmd, m_SorterArgs, m_GpuVisibleKeyCount);
 
             cmd.EndSample(s_ProfSort);
         }

--- a/package/Runtime/GaussianSplatRenderer.cs
+++ b/package/Runtime/GaussianSplatRenderer.cs
@@ -17,9 +17,12 @@ namespace GaussianSplatting.Runtime
     class GaussianSplatRenderSystem
     {
         // ReSharper disable MemberCanBePrivate.Global - used by HDRP/URP features that are not always compiled
-        internal static readonly ProfilerMarker s_ProfDraw = new(ProfilerCategory.Render, "GaussianSplat.Draw", MarkerFlags.SampleGPU);
-        internal static readonly ProfilerMarker s_ProfCompose = new(ProfilerCategory.Render, "GaussianSplat.Compose", MarkerFlags.SampleGPU);
-        internal static readonly ProfilerMarker s_ProfCalcView = new(ProfilerCategory.Render, "GaussianSplat.CalcView", MarkerFlags.SampleGPU);
+        internal static readonly ProfilerMarker s_ProfDraw =
+            new(ProfilerCategory.Render, "GaussianSplat.Draw", MarkerFlags.SampleGPU);
+        internal static readonly ProfilerMarker s_ProfCompose =
+            new(ProfilerCategory.Render, "GaussianSplat.Compose", MarkerFlags.SampleGPU);
+        internal static readonly ProfilerMarker s_ProfCalcView =
+            new(ProfilerCategory.Render, "GaussianSplat.CalcView", MarkerFlags.SampleGPU);
         // ReSharper restore MemberCanBePrivate.Global
 
         public static GaussianSplatRenderSystem instance => ms_Instance ??= new GaussianSplatRenderSystem();
@@ -44,9 +47,10 @@ namespace GaussianSplatting.Runtime
 
         public void UnregisterSplat(GaussianSplatRenderer r)
         {
-            if (!m_Splats.ContainsKey(r))
-                return;
+            if (!m_Splats.ContainsKey(r)) return;
+
             m_Splats.Remove(r);
+
             if (m_Splats.Count == 0)
             {
                 if (m_CameraCommandBuffersDone != null)
@@ -72,8 +76,8 @@ namespace GaussianSplatting.Runtime
         // ReSharper disable once MemberCanBePrivate.Global - used by HDRP/URP features that are not always compiled
         public bool GatherSplatsForCamera(Camera cam)
         {
-            if (cam.cameraType == CameraType.Preview)
-                return false;
+            if (cam.cameraType == CameraType.Preview) return false;
+
             // gather all active & valid splat objects
             m_ActiveSplats.Clear();
             foreach (var kvp in m_Splats)
@@ -83,8 +87,8 @@ namespace GaussianSplatting.Runtime
                     continue;
                 m_ActiveSplats.Add((kvp.Key, kvp.Value));
             }
-            if (m_ActiveSplats.Count == 0)
-                return false;
+
+            if (m_ActiveSplats.Count == 0) return false;
 
             // sort them by order and depth from camera
             var camTr = cam.transform;
@@ -92,8 +96,8 @@ namespace GaussianSplatting.Runtime
             {
                 var orderA = a.Item1.m_RenderOrder;
                 var orderB = b.Item1.m_RenderOrder;
-                if (orderA != orderB)
-                    return orderB.CompareTo(orderA);
+                if (orderA != orderB) return orderB.CompareTo(orderA);
+
                 var trA = a.Item1.transform;
                 var trB = b.Item1.transform;
                 var posA = camTr.InverseTransformPoint(trA.position);
@@ -108,11 +112,13 @@ namespace GaussianSplatting.Runtime
         public Material SortAndRenderSplats(Camera cam, CommandBuffer cmb)
         {
             Material matComposite = null;
+
             foreach (var kvp in m_ActiveSplats)
             {
                 var gs = kvp.Item1;
                 gs.EnsureMaterials();
                 matComposite = gs.m_MatComposite;
+
                 var mpb = kvp.Item2;
 
                 // sort
@@ -123,6 +129,7 @@ namespace GaussianSplatting.Runtime
 
                 // cache view
                 kvp.Item2.Clear();
+
                 Material displayMat = gs.m_RenderMode switch
                 {
                     GaussianSplatRenderer.RenderMode.DebugPoints => gs.m_MatDebugPoints,
@@ -131,40 +138,51 @@ namespace GaussianSplatting.Runtime
                     GaussianSplatRenderer.RenderMode.DebugChunkBounds => gs.m_MatDebugBoxes,
                     _ => gs.m_MatSplats
                 };
-                if (displayMat == null)
-                    continue;
+
+                if (displayMat == null) continue;
 
                 gs.SetAssetDataOnMaterial(mpb);
+
                 mpb.SetBuffer(GaussianSplatRenderer.Props.SplatChunks, gs.m_GpuChunks);
-
                 mpb.SetBuffer(GaussianSplatRenderer.Props.SplatViewData, gs.m_GpuView);
-
                 mpb.SetBuffer(GaussianSplatRenderer.Props.OrderBuffer, gs.m_GpuSortKeys);
                 mpb.SetFloat(GaussianSplatRenderer.Props.SplatScale, gs.m_SplatScale);
                 mpb.SetFloat(GaussianSplatRenderer.Props.SplatOpacityScale, gs.m_OpacityScale);
                 mpb.SetFloat(GaussianSplatRenderer.Props.SplatSize, gs.m_PointDisplaySize);
                 mpb.SetInteger(GaussianSplatRenderer.Props.SHOrder, gs.m_SHOrder);
                 mpb.SetInteger(GaussianSplatRenderer.Props.SHOnly, gs.m_SHOnly ? 1 : 0);
-                mpb.SetInteger(GaussianSplatRenderer.Props.DisplayIndex, gs.m_RenderMode == GaussianSplatRenderer.RenderMode.DebugPointIndices ? 1 : 0);
-                mpb.SetInteger(GaussianSplatRenderer.Props.DisplayChunks, gs.m_RenderMode == GaussianSplatRenderer.RenderMode.DebugChunkBounds ? 1 : 0);
+                mpb.SetInteger(GaussianSplatRenderer.Props.DisplayIndex,
+                    gs.m_RenderMode == GaussianSplatRenderer.RenderMode.DebugPointIndices ? 1 : 0);
+                mpb.SetInteger(GaussianSplatRenderer.Props.DisplayChunks,
+                    gs.m_RenderMode == GaussianSplatRenderer.RenderMode.DebugChunkBounds ? 1 : 0);
 
                 cmb.BeginSample(s_ProfCalcView);
                 gs.CalcViewData(cmb, cam);
                 cmb.EndSample(s_ProfCalcView);
 
                 // draw
-                int indexCount = 6;
-                int instanceCount = gs.splatCount;
                 MeshTopology topology = MeshTopology.Triangles;
-                if (gs.m_RenderMode is GaussianSplatRenderer.RenderMode.DebugBoxes or GaussianSplatRenderer.RenderMode.DebugChunkBounds)
-                    indexCount = 36;
-                if (gs.m_RenderMode == GaussianSplatRenderer.RenderMode.DebugChunkBounds)
-                    instanceCount = gs.m_GpuChunksValid ? gs.m_GpuChunks.count : 0;
 
-                cmb.BeginSample(s_ProfDraw);
-                cmb.DrawProcedural(gs.m_GpuIndexBuffer, matrix, displayMat, 0, topology, indexCount, instanceCount, mpb);
-                cmb.EndSample(s_ProfDraw);
+                if (gs.m_RenderMode == GaussianSplatRenderer.RenderMode.DebugChunkBounds)
+                {
+                    int indexCount = 36;
+                    int instanceCount = gs.m_GpuChunksValid ? gs.m_GpuChunks.count : 0;
+                    cmb.DrawProcedural(gs.m_GpuIndexBuffer, matrix, displayMat, 0, topology,
+                        indexCount, instanceCount, mpb);
+                }
+                else
+                {
+                    // Indirect args choose quad vs cube
+                    GraphicsBuffer args = gs.m_RenderMode == GaussianSplatRenderer.RenderMode.DebugBoxes
+                        ? gs.drawArgsCube
+                        : gs.drawArgsQuad;
+
+                    cmb.BeginSample(s_ProfDraw);
+                    cmb.DrawProceduralIndirect(gs.m_GpuIndexBuffer, matrix, displayMat, 0, topology, args, 0, mpb);
+                    cmb.EndSample(s_ProfDraw);
+                }
             }
+
             return matComposite;
         }
 
@@ -172,8 +190,11 @@ namespace GaussianSplatting.Runtime
         // ReSharper disable once UnusedMethodReturnValue.Global - used by HDRP/URP features that are not always compiled
         public CommandBuffer InitialClearCmdBuffer(Camera cam)
         {
-            m_CommandBuffer ??= new CommandBuffer {name = "RenderGaussianSplats"};
-            if (GraphicsSettings.currentRenderPipeline == null && cam != null && !m_CameraCommandBuffersDone.Contains(cam))
+            m_CommandBuffer ??= new CommandBuffer { name = "RenderGaussianSplats" };
+
+            if (GraphicsSettings.currentRenderPipeline == null &&
+                cam != null &&
+                !m_CameraCommandBuffersDone.Contains(cam))
             {
                 cam.AddCommandBuffer(CameraEvent.BeforeForwardAlpha, m_CommandBuffer);
                 m_CameraCommandBuffersDone.Add(cam);
@@ -186,18 +207,28 @@ namespace GaussianSplatting.Runtime
 
         void OnPreCullCamera(Camera cam)
         {
-            if (!GatherSplatsForCamera(cam))
-                return;
+            if (!GatherSplatsForCamera(cam)) return;
 
             InitialClearCmdBuffer(cam);
 
-            m_CommandBuffer.GetTemporaryRT(GaussianSplatRenderer.Props.GaussianSplatRT, -1, -1, 0, FilterMode.Point, GraphicsFormat.R16G16B16A16_SFloat);
-            m_CommandBuffer.SetRenderTarget(GaussianSplatRenderer.Props.GaussianSplatRT, BuiltinRenderTextureType.CurrentActive);
-            m_CommandBuffer.ClearRenderTarget(RTClearFlags.Color, new Color(0, 0, 0, 0), 0, 0);
+            m_CommandBuffer.GetTemporaryRT(
+                GaussianSplatRenderer.Props.GaussianSplatRT,
+                -1, -1, 0,
+                FilterMode.Point,
+                GraphicsFormat.R16G16B16A16_SFloat);
+
+            m_CommandBuffer.SetRenderTarget(
+                GaussianSplatRenderer.Props.GaussianSplatRT,
+                BuiltinRenderTextureType.CurrentActive);
+
+            m_CommandBuffer.ClearRenderTarget(
+                RTClearFlags.Color, new Color(0, 0, 0, 0), 0, 0);
 
             // We only need this to determine whether we're rendering into backbuffer or not. However, detection this
             // way only works in BiRP so only do it here.
-            m_CommandBuffer.SetGlobalTexture(GaussianSplatRenderer.Props.CameraTargetTexture, BuiltinRenderTextureType.CameraTarget);
+            m_CommandBuffer.SetGlobalTexture(
+                GaussianSplatRenderer.Props.CameraTargetTexture,
+                BuiltinRenderTextureType.CameraTarget);
 
             // add sorting, view calc and drawing commands for each splat object
             Material matComposite = SortAndRenderSplats(cam, m_CommandBuffer);
@@ -207,6 +238,7 @@ namespace GaussianSplatting.Runtime
             m_CommandBuffer.SetRenderTarget(BuiltinRenderTextureType.CameraTarget);
             m_CommandBuffer.DrawProcedural(Matrix4x4.identity, matComposite, 0, MeshTopology.Triangles, 3, 1);
             m_CommandBuffer.EndSample(s_ProfCompose);
+
             m_CommandBuffer.ReleaseTemporaryRT(GaussianSplatRenderer.Props.GaussianSplatRT);
         }
     }
@@ -222,24 +254,40 @@ namespace GaussianSplatting.Runtime
             DebugBoxes,
             DebugChunkBounds,
         }
+
         public GaussianSplatAsset m_Asset;
 
         [Tooltip("Rendering order compared to other splats. Within same order splats are sorted by distance. Higher order splats render 'on top of' lower order splats.")]
         public int m_RenderOrder;
-        [Range(0.1f, 2.0f)] [Tooltip("Additional scaling factor for the splats")]
+
+        [Range(0.1f, 2.0f)]
+        [Tooltip("Additional scaling factor for the splats")]
         public float m_SplatScale = 1.0f;
+
         [Range(0.05f, 20.0f)]
         [Tooltip("Additional scaling factor for opacity")]
         public float m_OpacityScale = 1.0f;
-        [Range(0, 3)] [Tooltip("Spherical Harmonics order to use")]
+
+        [Range(0, 3)]
+        [Tooltip("Spherical Harmonics order to use")]
         public int m_SHOrder = 3;
+
         [Tooltip("Show only Spherical Harmonics contribution, using gray color")]
         public bool m_SHOnly;
-        [Range(1,30)] [Tooltip("Sort splats only every N frames")]
+
+        [Range(1, 30)]
+        [Tooltip("Sort splats only every N frames")]
         public int m_SortNthFrame = 1;
 
         public RenderMode m_RenderMode = RenderMode.Splats;
-        [Range(1.0f,15.0f)] public float m_PointDisplaySize = 3.0f;
+
+        public bool m_PrintCulledSplats = false;
+
+        [Min(1)]
+        public int m_DebugCullReadbackEveryNFrames = 30;
+
+        [Range(1.0f, 15.0f)]
+        public float m_PointDisplaySize = 3.0f;
 
         public GaussianCutout[] m_Cutouts;
 
@@ -247,20 +295,45 @@ namespace GaussianSplatting.Runtime
         public Shader m_ShaderComposite;
         public Shader m_ShaderDebugPoints;
         public Shader m_ShaderDebugBoxes;
+
         [Tooltip("Gaussian splatting compute shader")]
         public ComputeShader m_CSSplatUtilities;
 
         int m_SplatCount; // initially same as asset splat count, but editing can change this
+
         GraphicsBuffer m_GpuSortDistances;
         internal GraphicsBuffer m_GpuSortKeys;
+
         GraphicsBuffer m_GpuPosData;
         GraphicsBuffer m_GpuOtherData;
         GraphicsBuffer m_GpuSHData;
         Texture m_GpuColorData;
+
         internal GraphicsBuffer m_GpuChunks;
         internal bool m_GpuChunksValid;
+
         internal GraphicsBuffer m_GpuView;
         internal GraphicsBuffer m_GpuIndexBuffer;
+
+        //buffers for frustum culling
+        GraphicsBuffer m_GpuVisibleKeyCount;
+        int m_LastVisibilityFrame = -1;
+        int m_LastVisibilityCameraId = 0;
+
+        //argument buffers for the indirect dispatch/draw commands
+        GraphicsBuffer m_GpuArgsDispatchVisible; // 3 uints
+        GraphicsBuffer m_GpuArgsDrawQuad;        // 5 uints
+        GraphicsBuffer m_GpuArgsDrawCube;        // 5 uints
+
+        internal GraphicsBuffer drawArgsQuad => m_GpuArgsDrawQuad;
+        internal GraphicsBuffer drawArgsCube => m_GpuArgsDrawCube;
+
+        // Debug: cull visible count readback
+        int m_LastCullDebugRequestFrame = -1;
+        int m_LastCullDebugRequestCamId = 0;
+        string m_LastCullDebugRequestCamName = "";
+        int m_LastCullDebugTotal = 0;
+        bool m_CullDebugReadbackPending = false;
 
         // these buffers are only for splat editing, and are lazily created
         GraphicsBuffer m_GpuEditCutouts;
@@ -268,8 +341,8 @@ namespace GaussianSplatting.Runtime
         GraphicsBuffer m_GpuEditSelected;
         GraphicsBuffer m_GpuEditDeleted;
         GraphicsBuffer m_GpuEditSelectedMouseDown; // selection state at start of operation
-        GraphicsBuffer m_GpuEditPosMouseDown; // position state at start of operation
-        GraphicsBuffer m_GpuEditOtherMouseDown; // rotation/scale state at start of operation
+        GraphicsBuffer m_GpuEditPosMouseDown;      // position state at start of operation
+        GraphicsBuffer m_GpuEditOtherMouseDown;    // rotation/scale state at start of operation
 
         GpuSorting m_Sorter;
         GpuSorting.Args m_SorterArgs;
@@ -280,11 +353,13 @@ namespace GaussianSplatting.Runtime
         internal Material m_MatDebugBoxes;
 
         internal int m_FrameCounter;
+
         GaussianSplatAsset m_PrevAsset;
         Hash128 m_PrevHash;
         bool m_Registered;
 
-        static readonly ProfilerMarker s_ProfSort = new(ProfilerCategory.Render, "GaussianSplat.Sort", MarkerFlags.SampleGPU);
+        static readonly ProfilerMarker s_ProfSort =
+            new(ProfilerCategory.Render, "GaussianSplat.Sort", MarkerFlags.SampleGPU);
 
         internal static class Props
         {
@@ -292,42 +367,63 @@ namespace GaussianSplatting.Runtime
             public static readonly int SplatOther = Shader.PropertyToID("_SplatOther");
             public static readonly int SplatSH = Shader.PropertyToID("_SplatSH");
             public static readonly int SplatColor = Shader.PropertyToID("_SplatColor");
+
             public static readonly int SplatSelectedBits = Shader.PropertyToID("_SplatSelectedBits");
             public static readonly int SplatDeletedBits = Shader.PropertyToID("_SplatDeletedBits");
             public static readonly int SplatBitsValid = Shader.PropertyToID("_SplatBitsValid");
+
             public static readonly int SplatFormat = Shader.PropertyToID("_SplatFormat");
             public static readonly int SplatChunks = Shader.PropertyToID("_SplatChunks");
             public static readonly int SplatChunkCount = Shader.PropertyToID("_SplatChunkCount");
             public static readonly int SplatViewData = Shader.PropertyToID("_SplatViewData");
             public static readonly int OrderBuffer = Shader.PropertyToID("_OrderBuffer");
+
             public static readonly int SplatScale = Shader.PropertyToID("_SplatScale");
             public static readonly int SplatOpacityScale = Shader.PropertyToID("_SplatOpacityScale");
             public static readonly int SplatSize = Shader.PropertyToID("_SplatSize");
             public static readonly int SplatCount = Shader.PropertyToID("_SplatCount");
+
             public static readonly int SHOrder = Shader.PropertyToID("_SHOrder");
             public static readonly int SHOnly = Shader.PropertyToID("_SHOnly");
+
             public static readonly int DisplayIndex = Shader.PropertyToID("_DisplayIndex");
             public static readonly int DisplayChunks = Shader.PropertyToID("_DisplayChunks");
+
             public static readonly int GaussianSplatRT = Shader.PropertyToID("_GaussianSplatRT");
+
             public static readonly int SplatSortKeys = Shader.PropertyToID("_SplatSortKeys");
             public static readonly int SplatSortDistances = Shader.PropertyToID("_SplatSortDistances");
+
             public static readonly int SrcBuffer = Shader.PropertyToID("_SrcBuffer");
             public static readonly int DstBuffer = Shader.PropertyToID("_DstBuffer");
             public static readonly int BufferSize = Shader.PropertyToID("_BufferSize");
+
             public static readonly int MatrixMV = Shader.PropertyToID("_MatrixMV");
             public static readonly int MatrixObjectToWorld = Shader.PropertyToID("_MatrixObjectToWorld");
             public static readonly int MatrixWorldToObject = Shader.PropertyToID("_MatrixWorldToObject");
+
             public static readonly int VecScreenParams = Shader.PropertyToID("_VecScreenParams");
             public static readonly int VecWorldSpaceCameraPos = Shader.PropertyToID("_VecWorldSpaceCameraPos");
+
             public static readonly int CameraTargetTexture = Shader.PropertyToID("_CameraTargetTexture");
+
             public static readonly int SelectionCenter = Shader.PropertyToID("_SelectionCenter");
             public static readonly int SelectionDelta = Shader.PropertyToID("_SelectionDelta");
             public static readonly int SelectionDeltaRot = Shader.PropertyToID("_SelectionDeltaRot");
+
             public static readonly int SplatCutoutsCount = Shader.PropertyToID("_SplatCutoutsCount");
             public static readonly int SplatCutouts = Shader.PropertyToID("_SplatCutouts");
             public static readonly int SelectionMode = Shader.PropertyToID("_SelectionMode");
+
             public static readonly int SplatPosMouseDown = Shader.PropertyToID("_SplatPosMouseDown");
             public static readonly int SplatOtherMouseDown = Shader.PropertyToID("_SplatOtherMouseDown");
+
+            public static readonly int VisibleKeyCount = Shader.PropertyToID("_VisibleKeyCount");
+            public static readonly int ObjectToWorldMaxAxisScale = Shader.PropertyToID("_ObjectToWorldMaxAxisScale");
+
+            public static readonly int ArgsDispatchVisible = Shader.PropertyToID("_ArgsDispatchVisible");
+            public static readonly int ArgsDrawQuad = Shader.PropertyToID("_ArgsDrawQuad");
+            public static readonly int ArgsDrawCube = Shader.PropertyToID("_ArgsDrawCube");
         }
 
         [field: NonSerialized] public bool editModified { get; private set; }
@@ -342,8 +438,11 @@ namespace GaussianSplatting.Runtime
         enum KernelIndices
         {
             SetIndices,
+            BuildIndirectArgs,
             CalcDistances,
             CalcViewData,
+            ClearVisibleKeyCount,
+            CullFrustum,
             UpdateEditData,
             InitEditData,
             ClearBuffer,
@@ -366,47 +465,80 @@ namespace GaussianSplatting.Runtime
             m_Asset.otherData != null &&
             m_Asset.shData != null &&
             m_Asset.colorData != null;
+
         public bool HasValidRenderSetup => m_GpuPosData != null && m_GpuOtherData != null && m_GpuChunks != null;
 
         const int kGpuViewDataSize = 40;
 
         void CreateResourcesForAsset()
         {
-            if (!HasValidAsset)
-                return;
+            if (!HasValidAsset) return;
 
             m_SplatCount = asset.splatCount;
-            m_GpuPosData = new GraphicsBuffer(GraphicsBuffer.Target.Raw | GraphicsBuffer.Target.CopySource, (int) (asset.posData.dataSize / 4), 4) { name = "GaussianPosData" };
+
+            m_GpuPosData = new GraphicsBuffer(
+                GraphicsBuffer.Target.Raw | GraphicsBuffer.Target.CopySource,
+                (int)(asset.posData.dataSize / 4),
+                4)
+            { name = "GaussianPosData" };
             m_GpuPosData.SetData(asset.posData.GetData<uint>());
-            m_GpuOtherData = new GraphicsBuffer(GraphicsBuffer.Target.Raw | GraphicsBuffer.Target.CopySource, (int) (asset.otherData.dataSize / 4), 4) { name = "GaussianOtherData" };
+
+            m_GpuOtherData = new GraphicsBuffer(
+                GraphicsBuffer.Target.Raw | GraphicsBuffer.Target.CopySource,
+                (int)(asset.otherData.dataSize / 4),
+                4)
+            { name = "GaussianOtherData" };
             m_GpuOtherData.SetData(asset.otherData.GetData<uint>());
-            m_GpuSHData = new GraphicsBuffer(GraphicsBuffer.Target.Raw, (int) (asset.shData.dataSize / 4), 4) { name = "GaussianSHData" };
+
+            m_GpuSHData = new GraphicsBuffer(
+                GraphicsBuffer.Target.Raw,
+                (int)(asset.shData.dataSize / 4),
+                4)
+            { name = "GaussianSHData" };
             m_GpuSHData.SetData(asset.shData.GetData<uint>());
+
             var (texWidth, texHeight) = GaussianSplatAsset.CalcTextureSize(asset.splatCount);
             var texFormat = GaussianSplatAsset.ColorFormatToGraphics(asset.colorFormat);
-            var tex = new Texture2D(texWidth, texHeight, texFormat, TextureCreationFlags.DontInitializePixels | TextureCreationFlags.IgnoreMipmapLimit | TextureCreationFlags.DontUploadUponCreate) { name = "GaussianColorData" };
+
+            var tex = new Texture2D(
+                texWidth,
+                texHeight,
+                texFormat,
+                TextureCreationFlags.DontInitializePixels |
+                TextureCreationFlags.IgnoreMipmapLimit |
+                TextureCreationFlags.DontUploadUponCreate)
+            { name = "GaussianColorData" };
+
             tex.SetPixelData(asset.colorData.GetData<byte>(), 0);
             tex.Apply(false, true);
             m_GpuColorData = tex;
+
             if (asset.chunkData != null && asset.chunkData.dataSize != 0)
             {
-                m_GpuChunks = new GraphicsBuffer(GraphicsBuffer.Target.Structured,
-                    (int) (asset.chunkData.dataSize / UnsafeUtility.SizeOf<GaussianSplatAsset.ChunkInfo>()),
-                    UnsafeUtility.SizeOf<GaussianSplatAsset.ChunkInfo>()) {name = "GaussianChunkData"};
+                m_GpuChunks = new GraphicsBuffer(
+                    GraphicsBuffer.Target.Structured,
+                    (int)(asset.chunkData.dataSize / UnsafeUtility.SizeOf<GaussianSplatAsset.ChunkInfo>()),
+                    UnsafeUtility.SizeOf<GaussianSplatAsset.ChunkInfo>())
+                { name = "GaussianChunkData" };
+
                 m_GpuChunks.SetData(asset.chunkData.GetData<GaussianSplatAsset.ChunkInfo>());
                 m_GpuChunksValid = true;
             }
             else
             {
                 // just a dummy chunk buffer
-                m_GpuChunks = new GraphicsBuffer(GraphicsBuffer.Target.Structured, 1,
-                    UnsafeUtility.SizeOf<GaussianSplatAsset.ChunkInfo>()) {name = "GaussianChunkData"};
+                m_GpuChunks = new GraphicsBuffer(
+                    GraphicsBuffer.Target.Structured,
+                    1,
+                    UnsafeUtility.SizeOf<GaussianSplatAsset.ChunkInfo>())
+                { name = "GaussianChunkData" };
+
                 m_GpuChunksValid = false;
             }
 
             m_GpuView = new GraphicsBuffer(GraphicsBuffer.Target.Structured, m_Asset.splatCount, kGpuViewDataSize);
-            m_GpuIndexBuffer = new GraphicsBuffer(GraphicsBuffer.Target.Index, 36, 2);
-            // cube indices, most often we use only the first quad
+
+            m_GpuIndexBuffer = new GraphicsBuffer(GraphicsBuffer.Target.Index, 36, 2); // cube indices, most often we use only the first quad
             m_GpuIndexBuffer.SetData(new ushort[]
             {
                 0, 1, 2, 1, 3, 2,
@@ -428,14 +560,19 @@ namespace GaussianSplatting.Runtime
 
             EnsureSorterAndRegister();
 
-            m_GpuSortDistances = new GraphicsBuffer(GraphicsBuffer.Target.Structured, count, 4) { name = "GaussianSplatSortDistances" };
-            m_GpuSortKeys = new GraphicsBuffer(GraphicsBuffer.Target.Structured, count, 4) { name = "GaussianSplatSortIndices" };
+            m_GpuSortDistances = new GraphicsBuffer(GraphicsBuffer.Target.Structured, count, 4)
+            { name = "GaussianSplatSortDistances" };
+
+            m_GpuSortKeys = new GraphicsBuffer(GraphicsBuffer.Target.Structured, count, 4)
+            { name = "GaussianSplatSortIndices" };
 
             // init keys buffer to splat indices
             m_CSSplatUtilities.SetBuffer((int)KernelIndices.SetIndices, Props.SplatSortKeys, m_GpuSortKeys);
             m_CSSplatUtilities.SetInt(Props.SplatCount, m_GpuSortDistances.count);
+
             m_CSSplatUtilities.GetKernelThreadGroupSizes((int)KernelIndices.SetIndices, out uint gsX, out _, out _);
-            m_CSSplatUtilities.Dispatch((int)KernelIndices.SetIndices, (m_GpuSortDistances.count + (int)gsX - 1)/(int)gsX, 1, 1);
+            m_CSSplatUtilities.Dispatch((int)KernelIndices.SetIndices,
+                (m_GpuSortDistances.count + (int)gsX - 1) / (int)gsX, 1, 1);
 
             m_SorterArgs.inputKeys = m_GpuSortDistances;
             m_SorterArgs.inputValues = m_GpuSortKeys;
@@ -444,17 +581,22 @@ namespace GaussianSplatting.Runtime
                 m_SorterArgs.resources = GpuSorting.SupportResources.Load((uint)count);
         }
 
-        bool resourcesAreSetUp => m_ShaderSplats != null && m_ShaderComposite != null && m_ShaderDebugPoints != null &&
-                                  m_ShaderDebugBoxes != null && m_CSSplatUtilities != null && SystemInfo.supportsComputeShaders;
+        bool resourcesAreSetUp =>
+            m_ShaderSplats != null &&
+            m_ShaderComposite != null &&
+            m_ShaderDebugPoints != null &&
+            m_ShaderDebugBoxes != null &&
+            m_CSSplatUtilities != null &&
+            SystemInfo.supportsComputeShaders;
 
         public void EnsureMaterials()
         {
             if (m_MatSplats == null && resourcesAreSetUp)
             {
-                m_MatSplats = new Material(m_ShaderSplats) {name = "GaussianSplats"};
-                m_MatComposite = new Material(m_ShaderComposite) {name = "GaussianClearDstAlpha"};
-                m_MatDebugPoints = new Material(m_ShaderDebugPoints) {name = "GaussianDebugPoints"};
-                m_MatDebugBoxes = new Material(m_ShaderDebugBoxes) {name = "GaussianDebugBoxes"};
+                m_MatSplats = new Material(m_ShaderSplats) { name = "GaussianSplats" };
+                m_MatComposite = new Material(m_ShaderComposite) { name = "GaussianClearDstAlpha" };
+                m_MatDebugPoints = new Material(m_ShaderDebugPoints) { name = "GaussianDebugPoints" };
+                m_MatDebugBoxes = new Material(m_ShaderDebugBoxes) { name = "GaussianDebugBoxes" };
             }
         }
 
@@ -472,35 +614,65 @@ namespace GaussianSplatting.Runtime
             }
         }
 
+        void EnsureCullBuffers(int splatCount)
+        {
+            if (m_GpuVisibleKeyCount == null)
+            {
+                m_GpuVisibleKeyCount = new GraphicsBuffer(
+                    GraphicsBuffer.Target.Raw | GraphicsBuffer.Target.CopySource,
+                    1, 4)
+                { name = "GaussianVisibleKeyCount" };
+            }
+        }
+
+        void EnsureIndirectArgsBuffers()
+        {
+            if (m_GpuArgsDispatchVisible == null)
+                m_GpuArgsDispatchVisible = new GraphicsBuffer(GraphicsBuffer.Target.IndirectArguments, 3, 4)
+                { name = "GaussianArgsDispatchVisible" };
+
+            if (m_GpuArgsDrawQuad == null)
+                m_GpuArgsDrawQuad = new GraphicsBuffer(GraphicsBuffer.Target.IndirectArguments, 5, 4)
+                { name = "GaussianArgsDrawQuad" };
+
+            if (m_GpuArgsDrawCube == null)
+                m_GpuArgsDrawCube = new GraphicsBuffer(GraphicsBuffer.Target.IndirectArguments, 5, 4)
+                { name = "GaussianArgsDrawCube" };
+        }
+
         public void OnEnable()
         {
             m_FrameCounter = 0;
-            if (!resourcesAreSetUp)
-                return;
+            if (!resourcesAreSetUp) return;
 
             EnsureMaterials();
             EnsureSorterAndRegister();
-
             CreateResourcesForAsset();
         }
 
         void SetAssetDataOnCS(CommandBuffer cmb, KernelIndices kernel)
         {
             ComputeShader cs = m_CSSplatUtilities;
-            int kernelIndex = (int) kernel;
+            int kernelIndex = (int)kernel;
+
             cmb.SetComputeBufferParam(cs, kernelIndex, Props.SplatPos, m_GpuPosData);
             cmb.SetComputeBufferParam(cs, kernelIndex, Props.SplatChunks, m_GpuChunks);
             cmb.SetComputeBufferParam(cs, kernelIndex, Props.SplatOther, m_GpuOtherData);
             cmb.SetComputeBufferParam(cs, kernelIndex, Props.SplatSH, m_GpuSHData);
             cmb.SetComputeTextureParam(cs, kernelIndex, Props.SplatColor, m_GpuColorData);
+
             cmb.SetComputeBufferParam(cs, kernelIndex, Props.SplatSelectedBits, m_GpuEditSelected ?? m_GpuPosData);
             cmb.SetComputeBufferParam(cs, kernelIndex, Props.SplatDeletedBits, m_GpuEditDeleted ?? m_GpuPosData);
+
             cmb.SetComputeBufferParam(cs, kernelIndex, Props.SplatViewData, m_GpuView);
             cmb.SetComputeBufferParam(cs, kernelIndex, Props.OrderBuffer, m_GpuSortKeys);
 
-            cmb.SetComputeIntParam(cs, Props.SplatBitsValid, m_GpuEditSelected != null && m_GpuEditDeleted != null ? 1 : 0);
+            cmb.SetComputeIntParam(cs, Props.SplatBitsValid,
+                m_GpuEditSelected != null && m_GpuEditDeleted != null ? 1 : 0);
+
             uint format = (uint)m_Asset.posFormat | ((uint)m_Asset.scaleFormat << 8) | ((uint)m_Asset.shFormat << 16);
             cmb.SetComputeIntParam(cs, Props.SplatFormat, (int)format);
+
             cmb.SetComputeIntParam(cs, Props.SplatCount, m_SplatCount);
             cmb.SetComputeIntParam(cs, Props.SplatChunkCount, m_GpuChunksValid ? m_GpuChunks.count : 0);
 
@@ -515,11 +687,14 @@ namespace GaussianSplatting.Runtime
             mat.SetBuffer(Props.SplatOther, m_GpuOtherData);
             mat.SetBuffer(Props.SplatSH, m_GpuSHData);
             mat.SetTexture(Props.SplatColor, m_GpuColorData);
+
             mat.SetBuffer(Props.SplatSelectedBits, m_GpuEditSelected ?? m_GpuPosData);
             mat.SetBuffer(Props.SplatDeletedBits, m_GpuEditDeleted ?? m_GpuPosData);
             mat.SetInt(Props.SplatBitsValid, m_GpuEditSelected != null && m_GpuEditDeleted != null ? 1 : 0);
+
             uint format = (uint)m_Asset.posFormat | ((uint)m_Asset.scaleFormat << 8) | ((uint)m_Asset.shFormat << 16);
             mat.SetInteger(Props.SplatFormat, (int)format);
+
             mat.SetInteger(Props.SplatCount, m_SplatCount);
             mat.SetInteger(Props.SplatChunkCount, m_GpuChunksValid ? m_GpuChunks.count : 0);
         }
@@ -538,11 +713,17 @@ namespace GaussianSplatting.Runtime
             DisposeBuffer(ref m_GpuOtherData);
             DisposeBuffer(ref m_GpuSHData);
             DisposeBuffer(ref m_GpuChunks);
-
             DisposeBuffer(ref m_GpuView);
             DisposeBuffer(ref m_GpuIndexBuffer);
+
             DisposeBuffer(ref m_GpuSortDistances);
             DisposeBuffer(ref m_GpuSortKeys);
+
+            DisposeBuffer(ref m_GpuVisibleKeyCount);
+
+            DisposeBuffer(ref m_GpuArgsDispatchVisible);
+            DisposeBuffer(ref m_GpuArgsDrawQuad);
+            DisposeBuffer(ref m_GpuArgsDrawCube);
 
             DisposeBuffer(ref m_GpuEditSelectedMouseDown);
             DisposeBuffer(ref m_GpuEditPosMouseDown);
@@ -578,18 +759,25 @@ namespace GaussianSplatting.Runtime
 
         internal void CalcViewData(CommandBuffer cmb, Camera cam)
         {
-            if (cam.cameraType == CameraType.Preview)
-                return;
+            if (cam.cameraType == CameraType.Preview) return;
 
             var tr = transform;
 
             Matrix4x4 matView = cam.worldToCameraMatrix;
             Matrix4x4 matO2W = tr.localToWorldMatrix;
             Matrix4x4 matW2O = tr.worldToLocalMatrix;
+
             int screenW = cam.pixelWidth, screenH = cam.pixelHeight;
             int eyeW = XRSettings.eyeTextureWidth, eyeH = XRSettings.eyeTextureHeight;
-            Vector4 screenPar = new Vector4(eyeW != 0 ? eyeW : screenW, eyeH != 0 ? eyeH : screenH, 0, 0);
+
+            Vector4 screenPar = new Vector4(
+                eyeW != 0 ? eyeW : screenW,
+                eyeH != 0 ? eyeH : screenH,
+                0, 0);
+
             Vector4 camPos = cam.transform.position;
+
+            UpdateVisibilityAndIndirectArgs(cmb, matO2W, cam);
 
             // calculate view dependent data for each splat
             SetAssetDataOnCS(cmb, KernelIndices.CalcViewData);
@@ -600,19 +788,142 @@ namespace GaussianSplatting.Runtime
 
             cmb.SetComputeVectorParam(m_CSSplatUtilities, Props.VecScreenParams, screenPar);
             cmb.SetComputeVectorParam(m_CSSplatUtilities, Props.VecWorldSpaceCameraPos, camPos);
+
             cmb.SetComputeFloatParam(m_CSSplatUtilities, Props.SplatScale, m_SplatScale);
             cmb.SetComputeFloatParam(m_CSSplatUtilities, Props.SplatOpacityScale, m_OpacityScale);
             cmb.SetComputeIntParam(m_CSSplatUtilities, Props.SHOrder, m_SHOrder);
             cmb.SetComputeIntParam(m_CSSplatUtilities, Props.SHOnly, m_SHOnly ? 1 : 0);
 
-            m_CSSplatUtilities.GetKernelThreadGroupSizes((int)KernelIndices.CalcViewData, out uint gsX, out _, out _);
-            cmb.DispatchCompute(m_CSSplatUtilities, (int)KernelIndices.CalcViewData, (m_GpuView.count + (int)gsX - 1)/(int)gsX, 1, 1);
+            cmb.SetComputeBufferParam(m_CSSplatUtilities, (int)KernelIndices.CalcViewData, Props.VisibleKeyCount, m_GpuVisibleKeyCount);
+            cmb.SetComputeBufferParam(m_CSSplatUtilities, (int)KernelIndices.CalcViewData, Props.SplatSortKeys, m_GpuSortKeys);
+
+            cmb.DispatchCompute(m_CSSplatUtilities, (int)KernelIndices.CalcViewData, m_GpuArgsDispatchVisible, 0);
+        }
+
+        void RequestCullDebugReadback(CommandBuffer cmb, Camera cam)
+        {
+            if (!m_PrintCulledSplats) return;
+            if (m_GpuVisibleKeyCount == null) return;
+
+            int every = Mathf.Max(1, m_DebugCullReadbackEveryNFrames);
+            int frame = Time.renderedFrameCount;
+            int camId = cam ? cam.GetInstanceID() : 0;
+
+            // throttle + avoid overlapping requests
+            if (m_CullDebugReadbackPending) return;
+            if (frame % every != 0) return;
+            if (m_LastCullDebugRequestFrame == frame && m_LastCullDebugRequestCamId == camId) return;
+
+            m_LastCullDebugRequestFrame = frame;
+            m_LastCullDebugRequestCamId = camId;
+            m_LastCullDebugRequestCamName = cam ? cam.name : "null";
+            m_LastCullDebugTotal = m_SplatCount;
+            m_CullDebugReadbackPending = true;
+
+            cmb.RequestAsyncReadback(m_GpuVisibleKeyCount, 4, 0, OnCullDebugReadback);
+        }
+
+        void OnCullDebugReadback(AsyncGPUReadbackRequest req)
+        {
+            m_CullDebugReadbackPending = false;
+
+            // check if object got disabled/destroyed before callback
+            if (!this || !m_PrintCulledSplats) return;
+            if (req.hasError) return;
+
+            uint visible = 0;
+            var data = req.GetData<uint>();
+            if (data.Length > 0) visible = data[0];
+
+            uint total = (uint)Mathf.Max(0, m_LastCullDebugTotal);
+            if (visible > total) visible = total;
+
+            Debug.Log($"[GaussianSplat] {name} ({m_LastCullDebugRequestCamName}): visible {visible}/{total}");
+        }
+
+        void DispatchCullAndBuildVisibleKeys(CommandBuffer cmb, Matrix4x4 localToWorld)
+        {
+            EnsureCullBuffers(m_SplatCount);
+
+            // clear visible-key counter
+            cmb.SetComputeBufferParam(m_CSSplatUtilities, (int)KernelIndices.ClearVisibleKeyCount, Props.VisibleKeyCount, m_GpuVisibleKeyCount);
+            cmb.DispatchCompute(m_CSSplatUtilities, (int)KernelIndices.ClearVisibleKeyCount, 1, 1, 1);
+
+            // bind common data
+            SetAssetDataOnCS(cmb, KernelIndices.CullFrustum);
+
+            // bind cull-specific data
+            cmb.SetComputeFloatParam(m_CSSplatUtilities, Props.SplatScale, m_SplatScale);
+            cmb.SetComputeMatrixParam(m_CSSplatUtilities, Props.MatrixObjectToWorld, localToWorld);
+            cmb.SetComputeBufferParam(m_CSSplatUtilities, (int)KernelIndices.CullFrustum, Props.VisibleKeyCount, m_GpuVisibleKeyCount);
+            cmb.SetComputeBufferParam(m_CSSplatUtilities, (int)KernelIndices.CullFrustum, Props.SplatSortKeys, m_GpuSortKeys);
+
+            // find the max scale axis (needed for scale approximation to avoid culling splats on the edge of the screen)
+            var ax = new Vector3(localToWorld.m00, localToWorld.m10, localToWorld.m20);
+            var ay = new Vector3(localToWorld.m01, localToWorld.m11, localToWorld.m21);
+            var az = new Vector3(localToWorld.m02, localToWorld.m12, localToWorld.m22);
+            float maxAxisScale = Mathf.Max(ax.magnitude, Mathf.Max(ay.magnitude, az.magnitude));
+            cmb.SetComputeFloatParam(m_CSSplatUtilities, Props.ObjectToWorldMaxAxisScale, maxAxisScale);
+
+            // dispatch
+            m_CSSplatUtilities.GetKernelThreadGroupSizes((int)KernelIndices.CullFrustum, out uint gsX, out _, out _);
+            cmb.DispatchCompute(m_CSSplatUtilities, (int)KernelIndices.CullFrustum,
+                (m_SplatCount + (int)gsX - 1) / (int)gsX, 1, 1);
+        }
+
+        void UpdateVisibilityAndIndirectArgs(CommandBuffer cmb, Matrix4x4 localToWorld, Camera cam)
+        {
+            // avoid updating twice in the same frame for the same camera (can happen due to m_SortNthFrame)
+            int camId = cam ? cam.GetInstanceID() : 0;
+            int frame = Time.renderedFrameCount;
+            if (m_LastVisibilityFrame == frame && m_LastVisibilityCameraId == camId) return;
+
+            m_LastVisibilityFrame = frame;
+            m_LastVisibilityCameraId = camId;
+
+            EnsureCullBuffers(m_SplatCount);
+            EnsureIndirectArgsBuffers();
+
+            // build m_GpuVisibleKeyCount and visible m_GpuSortKeys
+            DispatchCullAndBuildVisibleKeys(cmb, localToWorld);
+
+            // build indirect args from visible count for the indirect dispatches/draws
+            cmb.SetComputeIntParam(m_CSSplatUtilities, Props.SplatCount, m_SplatCount);
+            cmb.SetComputeBufferParam(m_CSSplatUtilities, (int)KernelIndices.BuildIndirectArgs, Props.VisibleKeyCount, m_GpuVisibleKeyCount);
+            cmb.SetComputeBufferParam(m_CSSplatUtilities, (int)KernelIndices.BuildIndirectArgs, Props.ArgsDispatchVisible, m_GpuArgsDispatchVisible);
+            cmb.SetComputeBufferParam(m_CSSplatUtilities, (int)KernelIndices.BuildIndirectArgs, Props.ArgsDrawQuad, m_GpuArgsDrawQuad);
+            cmb.SetComputeBufferParam(m_CSSplatUtilities, (int)KernelIndices.BuildIndirectArgs, Props.ArgsDrawCube, m_GpuArgsDrawCube);
+            cmb.DispatchCompute(m_CSSplatUtilities, (int)KernelIndices.BuildIndirectArgs, 1, 1, 1);
+
+            //For debugging: print the number of visible splats
+            RequestCullDebugReadback(cmb, cam);
         }
 
         internal void SortPoints(CommandBuffer cmd, Camera cam, Matrix4x4 matrix)
         {
-            if (cam.cameraType == CameraType.Preview)
-                return;
+            if (cam.cameraType == CameraType.Preview) return;
+
+            int sortCount = m_SplatCount;
+
+            //Frustum culling
+            UpdateVisibilityAndIndirectArgs(cmd, matrix, cam);
+
+            EnsureCullBuffers(m_SplatCount);
+            EnsureIndirectArgsBuffers();
+
+            // running DispatchCullAndBuildVisibleKeys inside UpdateVisibilityAndIndirectArgs is not reliable in edit mode.
+            // Therefore we run it here again.
+            bool editMode = !Application.isPlaying;
+            if (editMode)
+                DispatchCullAndBuildVisibleKeys(cmd, matrix);
+
+            // build indirect args buffers from m_GpuVisibleKeyCount
+            cmd.SetComputeIntParam(m_CSSplatUtilities, Props.SplatCount, m_SplatCount);
+            cmd.SetComputeBufferParam(m_CSSplatUtilities, (int)KernelIndices.BuildIndirectArgs, Props.VisibleKeyCount, m_GpuVisibleKeyCount);
+            cmd.SetComputeBufferParam(m_CSSplatUtilities, (int)KernelIndices.BuildIndirectArgs, Props.ArgsDispatchVisible, m_GpuArgsDispatchVisible);
+            cmd.SetComputeBufferParam(m_CSSplatUtilities, (int)KernelIndices.BuildIndirectArgs, Props.ArgsDrawQuad, m_GpuArgsDrawQuad);
+            cmd.SetComputeBufferParam(m_CSSplatUtilities, (int)KernelIndices.BuildIndirectArgs, Props.ArgsDrawCube, m_GpuArgsDrawCube);
+            cmd.DispatchCompute(m_CSSplatUtilities, (int)KernelIndices.BuildIndirectArgs, 1, 1, 1);
 
             Matrix4x4 worldToCamMatrix = cam.worldToCameraMatrix;
             worldToCamMatrix.m20 *= -1;
@@ -621,20 +932,25 @@ namespace GaussianSplatting.Runtime
 
             // calculate distance to the camera for each splat
             cmd.BeginSample(s_ProfSort);
+
             cmd.SetComputeBufferParam(m_CSSplatUtilities, (int)KernelIndices.CalcDistances, Props.SplatSortDistances, m_GpuSortDistances);
             cmd.SetComputeBufferParam(m_CSSplatUtilities, (int)KernelIndices.CalcDistances, Props.SplatSortKeys, m_GpuSortKeys);
             cmd.SetComputeBufferParam(m_CSSplatUtilities, (int)KernelIndices.CalcDistances, Props.SplatChunks, m_GpuChunks);
             cmd.SetComputeBufferParam(m_CSSplatUtilities, (int)KernelIndices.CalcDistances, Props.SplatPos, m_GpuPosData);
+            cmd.SetComputeBufferParam(m_CSSplatUtilities, (int)KernelIndices.CalcDistances, Props.VisibleKeyCount, m_GpuVisibleKeyCount);
+
             cmd.SetComputeIntParam(m_CSSplatUtilities, Props.SplatFormat, (int)m_Asset.posFormat);
             cmd.SetComputeMatrixParam(m_CSSplatUtilities, Props.MatrixMV, worldToCamMatrix * matrix);
-            cmd.SetComputeIntParam(m_CSSplatUtilities, Props.SplatCount, m_SplatCount);
+            cmd.SetComputeIntParam(m_CSSplatUtilities, Props.SplatCount, sortCount);
             cmd.SetComputeIntParam(m_CSSplatUtilities, Props.SplatChunkCount, m_GpuChunksValid ? m_GpuChunks.count : 0);
+
             m_CSSplatUtilities.GetKernelThreadGroupSizes((int)KernelIndices.CalcDistances, out uint gsX, out _, out _);
-            cmd.DispatchCompute(m_CSSplatUtilities, (int)KernelIndices.CalcDistances, (m_GpuSortDistances.count + (int)gsX - 1)/(int)gsX, 1, 1);
+            cmd.DispatchCompute(m_CSSplatUtilities, (int)KernelIndices.CalcDistances, m_GpuArgsDispatchVisible, 0);
 
             // sort the splats
             EnsureSorterAndRegister();
-            m_Sorter.Dispatch(cmd, m_SorterArgs);
+            m_Sorter.DispatchIndirectCount(cmd, m_SorterArgs, m_GpuVisibleKeyCount);
+
             cmd.EndSample(s_ProfSort);
         }
 
@@ -645,6 +961,7 @@ namespace GaussianSplatting.Runtime
             {
                 m_PrevAsset = m_Asset;
                 m_PrevHash = curHash;
+
                 if (resourcesAreSetUp)
                 {
                     DisposeResourcesForAsset();
@@ -652,7 +969,8 @@ namespace GaussianSplatting.Runtime
                 }
                 else
                 {
-                    Debug.LogError($"{nameof(GaussianSplatRenderer)} component is not set up correctly (Resource references are missing), or platform does not support compute shaders");
+                    Debug.LogError(
+                        $"{nameof(GaussianSplatRenderer)} component is not set up correctly (Resource references are missing), or platform does not support compute shaders");
                 }
             }
         }
@@ -660,20 +978,21 @@ namespace GaussianSplatting.Runtime
         public void ActivateCamera(int index)
         {
             Camera mainCam = Camera.main;
-            if (!mainCam)
-                return;
-            if (!m_Asset || m_Asset.cameras == null)
-                return;
+            if (!mainCam) return;
+            if (!m_Asset || m_Asset.cameras == null) return;
 
             var selfTr = transform;
             var camTr = mainCam.transform;
             var prevParent = camTr.parent;
+
             var cam = m_Asset.cameras[index];
+
             camTr.parent = selfTr;
             camTr.localPosition = cam.pos;
             camTr.localRotation = Quaternion.LookRotation(cam.axisZ, cam.axisY);
             camTr.parent = prevParent;
             camTr.localScale = Vector3.one;
+
 #if UNITY_EDITOR
             UnityEditor.EditorUtility.SetDirty(camTr);
 #endif
@@ -683,8 +1002,9 @@ namespace GaussianSplatting.Runtime
         {
             m_CSSplatUtilities.SetBuffer((int)KernelIndices.ClearBuffer, Props.DstBuffer, buf);
             m_CSSplatUtilities.SetInt(Props.BufferSize, buf.count);
+
             m_CSSplatUtilities.GetKernelThreadGroupSizes((int)KernelIndices.ClearBuffer, out uint gsX, out _, out _);
-            m_CSSplatUtilities.Dispatch((int)KernelIndices.ClearBuffer, (int)((buf.count+gsX-1)/gsX), 1, 1);
+            m_CSSplatUtilities.Dispatch((int)KernelIndices.ClearBuffer, (int)((buf.count + gsX - 1) / gsX), 1, 1);
         }
 
         void UnionGraphicsBuffers(GraphicsBuffer dst, GraphicsBuffer src)
@@ -692,8 +1012,9 @@ namespace GaussianSplatting.Runtime
             m_CSSplatUtilities.SetBuffer((int)KernelIndices.OrBuffers, Props.SrcBuffer, src);
             m_CSSplatUtilities.SetBuffer((int)KernelIndices.OrBuffers, Props.DstBuffer, dst);
             m_CSSplatUtilities.SetInt(Props.BufferSize, dst.count);
+
             m_CSSplatUtilities.GetKernelThreadGroupSizes((int)KernelIndices.OrBuffers, out uint gsX, out _, out _);
-            m_CSSplatUtilities.Dispatch((int)KernelIndices.OrBuffers, (int)((dst.count+gsX-1)/gsX), 1, 1);
+            m_CSSplatUtilities.Dispatch((int)KernelIndices.OrBuffers, (int)((dst.count + gsX - 1) / gsX), 1, 1);
         }
 
         static float SortableUintToFloat(uint v)
@@ -719,38 +1040,56 @@ namespace GaussianSplatting.Runtime
 
             using CommandBuffer cmb = new CommandBuffer();
             SetAssetDataOnCS(cmb, KernelIndices.UpdateEditData);
+
             cmb.SetComputeBufferParam(m_CSSplatUtilities, (int)KernelIndices.UpdateEditData, Props.DstBuffer, m_GpuEditCountsBounds);
             cmb.SetComputeIntParam(m_CSSplatUtilities, Props.BufferSize, m_GpuEditSelected.count);
+
             m_CSSplatUtilities.GetKernelThreadGroupSizes((int)KernelIndices.UpdateEditData, out uint gsX, out _, out _);
-            cmb.DispatchCompute(m_CSSplatUtilities, (int)KernelIndices.UpdateEditData, (int)((m_GpuEditSelected.count+gsX-1)/gsX), 1, 1);
+            cmb.DispatchCompute(m_CSSplatUtilities, (int)KernelIndices.UpdateEditData, (int)((m_GpuEditSelected.count + gsX - 1) / gsX), 1, 1);
+
             Graphics.ExecuteCommandBuffer(cmb);
 
             uint[] res = new uint[m_GpuEditCountsBounds.count];
             m_GpuEditCountsBounds.GetData(res);
+
             editSelectedSplats = res[0];
             editDeletedSplats = res[1];
             editCutSplats = res[2];
-            Vector3 min = new Vector3(SortableUintToFloat(res[3]), SortableUintToFloat(res[4]), SortableUintToFloat(res[5]));
-            Vector3 max = new Vector3(SortableUintToFloat(res[6]), SortableUintToFloat(res[7]), SortableUintToFloat(res[8]));
+
+            Vector3 min = new Vector3(
+                SortableUintToFloat(res[3]),
+                SortableUintToFloat(res[4]),
+                SortableUintToFloat(res[5]));
+
+            Vector3 max = new Vector3(
+                SortableUintToFloat(res[6]),
+                SortableUintToFloat(res[7]),
+                SortableUintToFloat(res[8]));
+
             Bounds bounds = default;
             bounds.SetMinMax(min, max);
+
             if (bounds.extents.sqrMagnitude < 0.01)
-                bounds.extents = new Vector3(0.1f,0.1f,0.1f);
+                bounds.extents = new Vector3(0.1f, 0.1f, 0.1f);
+
             editSelectedBounds = bounds;
         }
 
         void UpdateCutoutsBuffer()
         {
             int bufferSize = m_Cutouts?.Length ?? 0;
-            if (bufferSize == 0)
-                bufferSize = 1;
+            if (bufferSize == 0) bufferSize = 1;
+
             if (m_GpuEditCutouts == null || m_GpuEditCutouts.count != bufferSize)
             {
                 m_GpuEditCutouts?.Dispose();
-                m_GpuEditCutouts = new GraphicsBuffer(GraphicsBuffer.Target.Structured, bufferSize, UnsafeUtility.SizeOf<GaussianCutout.ShaderData>()) { name = "GaussianCutouts" };
+                m_GpuEditCutouts = new GraphicsBuffer(GraphicsBuffer.Target.Structured, bufferSize,
+                    UnsafeUtility.SizeOf<GaussianCutout.ShaderData>())
+                { name = "GaussianCutouts" };
             }
 
             NativeArray<GaussianCutout.ShaderData> data = new(bufferSize, Allocator.Temp);
+
             if (m_Cutouts != null)
             {
                 var matrix = transform.localToWorldMatrix;
@@ -766,22 +1105,24 @@ namespace GaussianSplatting.Runtime
 
         bool EnsureEditingBuffers()
         {
-            if (!HasValidAsset || !HasValidRenderSetup)
-                return false;
+            if (!HasValidAsset || !HasValidRenderSetup) return false;
 
             if (m_GpuEditSelected == null)
             {
-                var target = GraphicsBuffer.Target.Raw | GraphicsBuffer.Target.CopySource |
-                             GraphicsBuffer.Target.CopyDestination;
+                var target = GraphicsBuffer.Target.Raw | GraphicsBuffer.Target.CopySource | GraphicsBuffer.Target.CopyDestination;
                 var size = (m_SplatCount + 31) / 32;
-                m_GpuEditSelected = new GraphicsBuffer(target, size, 4) {name = "GaussianSplatSelected"};
-                m_GpuEditSelectedMouseDown = new GraphicsBuffer(target, size, 4) {name = "GaussianSplatSelectedInit"};
-                m_GpuEditDeleted = new GraphicsBuffer(target, size, 4) {name = "GaussianSplatDeleted"};
-                m_GpuEditCountsBounds = new GraphicsBuffer(target, 3 + 6, 4) {name = "GaussianSplatEditData"}; // selected count, deleted bound, cut count, float3 min, float3 max
+
+                m_GpuEditSelected = new GraphicsBuffer(target, size, 4) { name = "GaussianSplatSelected" };
+                m_GpuEditSelectedMouseDown = new GraphicsBuffer(target, size, 4) { name = "GaussianSplatSelectedInit" };
+                m_GpuEditDeleted = new GraphicsBuffer(target, size, 4) { name = "GaussianSplatDeleted" };
+                m_GpuEditCountsBounds = new GraphicsBuffer(target, 3 + 6, 4) { name = "GaussianSplatEditData" };
+                // selected count, deleted bound, cut count, float3 min, float3 max
+
                 ClearGraphicsBuffer(m_GpuEditSelected);
                 ClearGraphicsBuffer(m_GpuEditSelectedMouseDown);
                 ClearGraphicsBuffer(m_GpuEditDeleted);
             }
+
             return m_GpuEditSelected != null;
         }
 
@@ -795,16 +1136,27 @@ namespace GaussianSplatting.Runtime
         {
             if (m_GpuEditPosMouseDown == null)
             {
-                m_GpuEditPosMouseDown = new GraphicsBuffer(m_GpuPosData.target | GraphicsBuffer.Target.CopyDestination, m_GpuPosData.count, m_GpuPosData.stride) {name = "GaussianSplatEditPosMouseDown"};
+                m_GpuEditPosMouseDown = new GraphicsBuffer(
+                    m_GpuPosData.target | GraphicsBuffer.Target.CopyDestination,
+                    m_GpuPosData.count,
+                    m_GpuPosData.stride)
+                { name = "GaussianSplatEditPosMouseDown" };
             }
+
             Graphics.CopyBuffer(m_GpuPosData, m_GpuEditPosMouseDown);
         }
+
         public void EditStoreOtherMouseDown()
         {
             if (m_GpuEditOtherMouseDown == null)
             {
-                m_GpuEditOtherMouseDown = new GraphicsBuffer(m_GpuOtherData.target | GraphicsBuffer.Target.CopyDestination, m_GpuOtherData.count, m_GpuOtherData.stride) {name = "GaussianSplatEditOtherMouseDown"};
+                m_GpuEditOtherMouseDown = new GraphicsBuffer(
+                    m_GpuOtherData.target | GraphicsBuffer.Target.CopyDestination,
+                    m_GpuOtherData.count,
+                    m_GpuOtherData.stride)
+                { name = "GaussianSplatEditOtherMouseDown" };
             }
+
             Graphics.CopyBuffer(m_GpuOtherData, m_GpuEditOtherMouseDown);
         }
 
@@ -818,8 +1170,10 @@ namespace GaussianSplatting.Runtime
             Matrix4x4 matView = cam.worldToCameraMatrix;
             Matrix4x4 matO2W = tr.localToWorldMatrix;
             Matrix4x4 matW2O = tr.worldToLocalMatrix;
+
             int screenW = cam.pixelWidth, screenH = cam.pixelHeight;
             Vector4 screenPar = new Vector4(screenW, screenH, 0, 0);
+
             Vector4 camPos = cam.transform.position;
 
             using var cmb = new CommandBuffer { name = "SplatSelectionUpdate" };
@@ -832,7 +1186,8 @@ namespace GaussianSplatting.Runtime
             cmb.SetComputeVectorParam(m_CSSplatUtilities, Props.VecScreenParams, screenPar);
             cmb.SetComputeVectorParam(m_CSSplatUtilities, Props.VecWorldSpaceCameraPos, camPos);
 
-            cmb.SetComputeVectorParam(m_CSSplatUtilities, "_SelectionRect", new Vector4(rectMin.x, rectMax.y, rectMax.x, rectMin.y));
+            cmb.SetComputeVectorParam(m_CSSplatUtilities, "_SelectionRect",
+                new Vector4(rectMin.x, rectMax.y, rectMax.x, rectMin.y));
             cmb.SetComputeIntParam(m_CSSplatUtilities, Props.SelectionMode, subtract ? 0 : 1);
 
             DispatchUtilsAndExecute(cmb, KernelIndices.SelectionUpdate, m_SplatCount);
@@ -863,16 +1218,17 @@ namespace GaussianSplatting.Runtime
 
             cmb.SetComputeBufferParam(m_CSSplatUtilities, (int)KernelIndices.RotateSelection, Props.SplatPosMouseDown, m_GpuEditPosMouseDown);
             cmb.SetComputeBufferParam(m_CSSplatUtilities, (int)KernelIndices.RotateSelection, Props.SplatOtherMouseDown, m_GpuEditOtherMouseDown);
+
             cmb.SetComputeVectorParam(m_CSSplatUtilities, Props.SelectionCenter, localSpaceCenter);
             cmb.SetComputeMatrixParam(m_CSSplatUtilities, Props.MatrixObjectToWorld, localToWorld);
             cmb.SetComputeMatrixParam(m_CSSplatUtilities, Props.MatrixWorldToObject, worldToLocal);
-            cmb.SetComputeVectorParam(m_CSSplatUtilities, Props.SelectionDeltaRot, new Vector4(rotation.x, rotation.y, rotation.z, rotation.w));
+            cmb.SetComputeVectorParam(m_CSSplatUtilities, Props.SelectionDeltaRot,
+                new Vector4(rotation.x, rotation.y, rotation.z, rotation.w));
 
             DispatchUtilsAndExecute(cmb, KernelIndices.RotateSelection, m_SplatCount);
             UpdateEditCountsAndBounds();
             editModified = true;
         }
-
 
         public void EditScaleSelection(Vector3 localSpaceCenter, Matrix4x4 localToWorld, Matrix4x4 worldToLocal, Vector3 scale)
         {
@@ -883,6 +1239,7 @@ namespace GaussianSplatting.Runtime
             SetAssetDataOnCS(cmb, KernelIndices.ScaleSelection);
 
             cmb.SetComputeBufferParam(m_CSSplatUtilities, (int)KernelIndices.ScaleSelection, Props.SplatPosMouseDown, m_GpuEditPosMouseDown);
+
             cmb.SetComputeVectorParam(m_CSSplatUtilities, Props.SelectionCenter, localSpaceCenter);
             cmb.SetComputeMatrixParam(m_CSSplatUtilities, Props.MatrixObjectToWorld, localToWorld);
             cmb.SetComputeMatrixParam(m_CSSplatUtilities, Props.MatrixWorldToObject, worldToLocal);
@@ -896,9 +1253,11 @@ namespace GaussianSplatting.Runtime
         public void EditDeleteSelected()
         {
             if (!EnsureEditingBuffers()) return;
+
             UnionGraphicsBuffers(m_GpuEditDeleted, m_GpuEditSelected);
             EditDeselectAll();
             UpdateEditCountsAndBounds();
+
             if (editDeletedSplats != 0)
                 editModified = true;
         }
@@ -906,10 +1265,13 @@ namespace GaussianSplatting.Runtime
         public void EditSelectAll()
         {
             if (!EnsureEditingBuffers()) return;
+
             using var cmb = new CommandBuffer { name = "SplatSelectAll" };
             SetAssetDataOnCS(cmb, KernelIndices.SelectAll);
+
             cmb.SetComputeBufferParam(m_CSSplatUtilities, (int)KernelIndices.SelectAll, Props.DstBuffer, m_GpuEditSelected);
             cmb.SetComputeIntParam(m_CSSplatUtilities, Props.BufferSize, m_GpuEditSelected.count);
+
             DispatchUtilsAndExecute(cmb, KernelIndices.SelectAll, m_GpuEditSelected.count);
             UpdateEditCountsAndBounds();
         }
@@ -927,8 +1289,10 @@ namespace GaussianSplatting.Runtime
 
             using var cmb = new CommandBuffer { name = "SplatInvertSelection" };
             SetAssetDataOnCS(cmb, KernelIndices.InvertSelection);
+
             cmb.SetComputeBufferParam(m_CSSplatUtilities, (int)KernelIndices.InvertSelection, Props.DstBuffer, m_GpuEditSelected);
             cmb.SetComputeIntParam(m_CSSplatUtilities, Props.BufferSize, m_GpuEditSelected.count);
+
             DispatchUtilsAndExecute(cmb, KernelIndices.InvertSelection, m_GpuEditSelected.count);
             UpdateEditCountsAndBounds();
         }
@@ -941,16 +1305,17 @@ namespace GaussianSplatting.Runtime
             var tr = transform;
             Quaternion bakeRot = tr.localRotation;
             Vector3 bakeScale = tr.localScale;
-
-            if (bakeTransform)
-                flags = 1;
+            if (bakeTransform) flags = 1;
 
             using var cmb = new CommandBuffer { name = "SplatExportData" };
             SetAssetDataOnCS(cmb, KernelIndices.ExportData);
+
             cmb.SetComputeIntParam(m_CSSplatUtilities, "_ExportTransformFlags", flags);
-            cmb.SetComputeVectorParam(m_CSSplatUtilities, "_ExportTransformRotation", new Vector4(bakeRot.x, bakeRot.y, bakeRot.z, bakeRot.w));
+            cmb.SetComputeVectorParam(m_CSSplatUtilities, "_ExportTransformRotation",
+                new Vector4(bakeRot.x, bakeRot.y, bakeRot.z, bakeRot.w));
             cmb.SetComputeVectorParam(m_CSSplatUtilities, "_ExportTransformScale", bakeScale);
             cmb.SetComputeMatrixParam(m_CSSplatUtilities, Props.MatrixObjectToWorld, tr.localToWorldMatrix);
+
             cmb.SetComputeBufferParam(m_CSSplatUtilities, (int)KernelIndices.ExportData, "_ExportBuffer", dstData);
 
             DispatchUtilsAndExecute(cmb, KernelIndices.ExportData, m_SplatCount);
@@ -964,44 +1329,62 @@ namespace GaussianSplatting.Runtime
                 Debug.LogError($"Invalid new splat count: {newSplatCount}");
                 return;
             }
+
             if (asset.chunkData != null)
             {
                 Debug.LogError("Only splats with VeryHigh quality can be resized");
                 return;
             }
-            if (newSplatCount == splatCount)
-                return;
+
+            if (newSplatCount == splatCount) return;
 
             int posStride = (int)(asset.posData.dataSize / asset.splatCount);
             int otherStride = (int)(asset.otherData.dataSize / asset.splatCount);
-            int shStride = (int) (asset.shData.dataSize / asset.splatCount);
+            int shStride = (int)(asset.shData.dataSize / asset.splatCount);
 
             // create new GPU buffers
-            var newPosData = new GraphicsBuffer(GraphicsBuffer.Target.Raw | GraphicsBuffer.Target.CopySource, newSplatCount * posStride / 4, 4) { name = "GaussianPosData" };
-            var newOtherData = new GraphicsBuffer(GraphicsBuffer.Target.Raw | GraphicsBuffer.Target.CopySource, newSplatCount * otherStride / 4, 4) { name = "GaussianOtherData" };
-            var newSHData = new GraphicsBuffer(GraphicsBuffer.Target.Raw, newSplatCount * shStride / 4, 4) { name = "GaussianSHData" };
+            var newPosData = new GraphicsBuffer(GraphicsBuffer.Target.Raw | GraphicsBuffer.Target.CopySource,
+                newSplatCount * posStride / 4, 4)
+            { name = "GaussianPosData" };
+
+            var newOtherData = new GraphicsBuffer(GraphicsBuffer.Target.Raw | GraphicsBuffer.Target.CopySource,
+                newSplatCount * otherStride / 4, 4)
+            { name = "GaussianOtherData" };
+
+            var newSHData = new GraphicsBuffer(GraphicsBuffer.Target.Raw,
+                newSplatCount * shStride / 4, 4)
+            { name = "GaussianSHData" };
 
             // new texture is a RenderTexture so we can write to it from a compute shader
             var (texWidth, texHeight) = GaussianSplatAsset.CalcTextureSize(newSplatCount);
             var texFormat = GaussianSplatAsset.ColorFormatToGraphics(asset.colorFormat);
-            var newColorData = new RenderTexture(texWidth, texHeight, texFormat, GraphicsFormat.None) { name = "GaussianColorData", enableRandomWrite = true };
+
+            var newColorData = new RenderTexture(texWidth, texHeight, texFormat, GraphicsFormat.None)
+            {
+                name = "GaussianColorData",
+                enableRandomWrite = true
+            };
             newColorData.Create();
 
             // selected/deleted buffers
             var selTarget = GraphicsBuffer.Target.Raw | GraphicsBuffer.Target.CopySource | GraphicsBuffer.Target.CopyDestination;
             var selSize = (newSplatCount + 31) / 32;
-            var newEditSelected = new GraphicsBuffer(selTarget, selSize, 4) {name = "GaussianSplatSelected"};
-            var newEditSelectedMouseDown = new GraphicsBuffer(selTarget, selSize, 4) {name = "GaussianSplatSelectedInit"};
-            var newEditDeleted = new GraphicsBuffer(selTarget, selSize, 4) {name = "GaussianSplatDeleted"};
+
+            var newEditSelected = new GraphicsBuffer(selTarget, selSize, 4) { name = "GaussianSplatSelected" };
+            var newEditSelectedMouseDown = new GraphicsBuffer(selTarget, selSize, 4) { name = "GaussianSplatSelectedInit" };
+            var newEditDeleted = new GraphicsBuffer(selTarget, selSize, 4) { name = "GaussianSplatDeleted" };
+
             ClearGraphicsBuffer(newEditSelected);
             ClearGraphicsBuffer(newEditSelectedMouseDown);
             ClearGraphicsBuffer(newEditDeleted);
 
             var newGpuView = new GraphicsBuffer(GraphicsBuffer.Target.Structured, newSplatCount, kGpuViewDataSize);
+
             InitSortBuffers(newSplatCount);
 
             // copy existing data over into new buffers
-            EditCopySplats(transform, newPosData, newOtherData, newSHData, newColorData, newEditDeleted, newSplatCount, 0, 0, m_SplatCount);
+            EditCopySplats(transform, newPosData, newOtherData, newSHData, newColorData, newEditDeleted,
+                newSplatCount, 0, 0, m_SplatCount);
 
             // use the new buffers and the new splat count
             m_GpuPosData.Dispose();
@@ -1019,6 +1402,7 @@ namespace GaussianSplatting.Runtime
             m_GpuSHData = newSHData;
             m_GpuColorData = newColorData;
             m_GpuView = newGpuView;
+
             m_GpuEditSelected = newEditSelected;
             m_GpuEditSelectedMouseDown = newEditSelectedMouseDown;
             m_GpuEditDeleted = newEditDeleted;
@@ -1034,18 +1418,30 @@ namespace GaussianSplatting.Runtime
         {
             EditCopySplats(
                 dst.transform,
-                dst.m_GpuPosData, dst.m_GpuOtherData, dst.m_GpuSHData, dst.m_GpuColorData, dst.m_GpuEditDeleted,
+                dst.m_GpuPosData,
+                dst.m_GpuOtherData,
+                dst.m_GpuSHData,
+                dst.m_GpuColorData,
+                dst.m_GpuEditDeleted,
                 dst.splatCount,
-                copySrcStartIndex, copyDstStartIndex, copyCount);
+                copySrcStartIndex,
+                copyDstStartIndex,
+                copyCount);
+
             dst.editModified = true;
         }
 
         public void EditCopySplats(
             Transform dstTransform,
-            GraphicsBuffer dstPos, GraphicsBuffer dstOther, GraphicsBuffer dstSH, Texture dstColor,
+            GraphicsBuffer dstPos,
+            GraphicsBuffer dstOther,
+            GraphicsBuffer dstSH,
+            Texture dstColor,
             GraphicsBuffer dstEditDeleted,
             int dstSize,
-            int copySrcStartIndex, int copyDstStartIndex, int copyCount)
+            int copySrcStartIndex,
+            int copyDstStartIndex,
+            int copyCount)
         {
             if (!EnsureEditingBuffers()) return;
 
@@ -1067,7 +1463,8 @@ namespace GaussianSplatting.Runtime
             cmb.SetComputeIntParam(m_CSSplatUtilities, "_CopyDstStartIndex", copyDstStartIndex);
             cmb.SetComputeIntParam(m_CSSplatUtilities, "_CopyCount", copyCount);
 
-            cmb.SetComputeVectorParam(m_CSSplatUtilities, "_CopyTransformRotation", new Vector4(copyRot.x, copyRot.y, copyRot.z, copyRot.w));
+            cmb.SetComputeVectorParam(m_CSSplatUtilities, "_CopyTransformRotation",
+                new Vector4(copyRot.x, copyRot.y, copyRot.z, copyRot.w));
             cmb.SetComputeVectorParam(m_CSSplatUtilities, "_CopyTransformScale", copyScale);
             cmb.SetComputeMatrixParam(m_CSSplatUtilities, "_CopyTransformMatrix", copyMatrix);
 
@@ -1077,7 +1474,7 @@ namespace GaussianSplatting.Runtime
         void DispatchUtilsAndExecute(CommandBuffer cmb, KernelIndices kernel, int count)
         {
             m_CSSplatUtilities.GetKernelThreadGroupSizes((int)kernel, out uint gsX, out _, out _);
-            cmb.DispatchCompute(m_CSSplatUtilities, (int)kernel, (int)((count + gsX - 1)/gsX), 1, 1);
+            cmb.DispatchCompute(m_CSSplatUtilities, (int)kernel, (int)((count + gsX - 1) / gsX), 1, 1);
             Graphics.ExecuteCommandBuffer(cmb);
         }
 

--- a/package/Runtime/GpuSorting.cs
+++ b/package/Runtime/GpuSorting.cs
@@ -196,5 +196,66 @@ namespace GaussianSplatting.Runtime
                 (srcPayloadBuffer, dstPayloadBuffer) = (dstPayloadBuffer, srcPayloadBuffer);
             }
         }
+
+        public void DispatchIndirectCount(CommandBuffer cmd, Args args, GraphicsBuffer sortCountBuffer)
+        {
+            Assert.IsTrue(Valid);
+
+            GraphicsBuffer srcKeyBuffer = args.inputKeys;
+            GraphicsBuffer srcPayloadBuffer = args.inputValues;
+            GraphicsBuffer dstKeyBuffer = args.resources.altBuffer;
+            GraphicsBuffer dstPayloadBuffer = args.resources.altPayloadBuffer;
+
+            // We still dispatch for the MAX capacity (args.count), resources were allocated for that.
+            uint maxCount = args.count;
+            uint maxThreadBlocks = DivRoundUp(maxCount, DEVICE_RADIX_SORT_PARTITION_SIZE);
+
+            // Keep these as MAX; shader will clamp to b_sortCount for real work.
+            cmd.SetComputeIntParam(m_CS, "e_numKeys", (int)maxCount);
+            cmd.SetComputeIntParam(m_CS, "e_threadBlocks", (int)maxThreadBlocks);
+
+            // Bind the GPU count buffer to every kernel that needs numKeys/partial behavior
+            cmd.SetComputeBufferParam(m_CS, m_kernelUpsweep,   "b_sortCount", sortCountBuffer);
+            cmd.SetComputeBufferParam(m_CS, m_kernelScan,      "b_sortCount", sortCountBuffer);
+            cmd.SetComputeBufferParam(m_CS, m_kernelDownsweep, "b_sortCount", sortCountBuffer);
+
+            // Static buffers
+            cmd.SetComputeBufferParam(m_CS, m_kernelUpsweep, "b_passHist", args.resources.passHistBuffer);
+            cmd.SetComputeBufferParam(m_CS, m_kernelUpsweep, "b_globalHist", args.resources.globalHistBuffer);
+
+            cmd.SetComputeBufferParam(m_CS, m_kernelScan, "b_passHist", args.resources.passHistBuffer);
+
+            cmd.SetComputeBufferParam(m_CS, m_kernelDownsweep, "b_passHist", args.resources.passHistBuffer);
+            cmd.SetComputeBufferParam(m_CS, m_kernelDownsweep, "b_globalHist", args.resources.globalHistBuffer);
+
+            // Clear global histogram
+            cmd.SetComputeBufferParam(m_CS, m_kernelInitDeviceRadixSort, "b_globalHist", args.resources.globalHistBuffer);
+            cmd.DispatchCompute(m_CS, m_kernelInitDeviceRadixSort, 1, 1, 1);
+
+            // 4 passes
+            for (uint radixShift = 0; radixShift < 32; radixShift += DEVICE_RADIX_SORT_BITS)
+            {
+                cmd.SetComputeIntParam(m_CS, "e_radixShift", (int)radixShift);
+
+                // Upsweep (dispatch MAX blocks; shader clamps via b_sortCount)
+                cmd.SetComputeBufferParam(m_CS, m_kernelUpsweep, "b_sort", srcKeyBuffer);
+                cmd.DispatchCompute(m_CS, m_kernelUpsweep, (int)maxThreadBlocks, 1, 1);
+
+                // Scan is fixed size
+                cmd.DispatchCompute(m_CS, m_kernelScan, (int)DEVICE_RADIX_SORT_RADIX, 1, 1);
+
+                // Downsweep (dispatch MAX blocks; shader early-outs gid>=activeBlocks)
+                cmd.SetComputeBufferParam(m_CS, m_kernelDownsweep, "b_sort", srcKeyBuffer);
+                cmd.SetComputeBufferParam(m_CS, m_kernelDownsweep, "b_sortPayload", srcPayloadBuffer);
+                cmd.SetComputeBufferParam(m_CS, m_kernelDownsweep, "b_alt", dstKeyBuffer);
+                cmd.SetComputeBufferParam(m_CS, m_kernelDownsweep, "b_altPayload", dstPayloadBuffer);
+                cmd.DispatchCompute(m_CS, m_kernelDownsweep, (int)maxThreadBlocks, 1, 1);
+
+                // Swap
+                (srcKeyBuffer, dstKeyBuffer) = (dstKeyBuffer, srcKeyBuffer);
+                (srcPayloadBuffer, dstPayloadBuffer) = (dstPayloadBuffer, srcPayloadBuffer);
+            }
+        }
+
     }
 }

--- a/package/Runtime/GpuSorting.cs
+++ b/package/Runtime/GpuSorting.cs
@@ -44,6 +44,7 @@ namespace GaussianSplatting.Runtime
             public GraphicsBuffer altPayloadBuffer;
             public GraphicsBuffer passHistBuffer;
             public GraphicsBuffer globalHistBuffer;
+            public GraphicsBuffer dispatchArgs;
 
             public static SupportResources Load(uint count)
             {
@@ -58,6 +59,7 @@ namespace GaussianSplatting.Runtime
                     altPayloadBuffer = new GraphicsBuffer(target, (int)count, 4) { name = "DeviceRadixAltPayload" },
                     passHistBuffer = new GraphicsBuffer(target, (int)scratchBufferSize, 4) { name = "DeviceRadixPassHistogram" },
                     globalHistBuffer = new GraphicsBuffer(target, (int)reducedScratchBufferSize, 4) { name = "DeviceRadixGlobalHistogram" },
+                    dispatchArgs = new GraphicsBuffer(GraphicsBuffer.Target.IndirectArguments | GraphicsBuffer.Target.Raw, 3, 4) { name = "DeviceRadixDispatchArgs" }
                 };
                 return resources;
             }
@@ -68,19 +70,23 @@ namespace GaussianSplatting.Runtime
                 altPayloadBuffer?.Dispose();
                 passHistBuffer?.Dispose();
                 globalHistBuffer?.Dispose();
+                dispatchArgs?.Dispose();
 
                 altBuffer = null;
                 altPayloadBuffer = null;
                 passHistBuffer = null;
                 globalHistBuffer = null;
+                dispatchArgs = null;
             }
         }
+
 
         readonly ComputeShader m_CS;
         readonly int m_kernelInitDeviceRadixSort = -1;
         readonly int m_kernelUpsweep = -1;
         readonly int m_kernelScan = -1;
         readonly int m_kernelDownsweep = -1;
+        readonly int m_kernelBuildIndirectArgs = -1;
 
         readonly bool m_Valid;
 
@@ -95,18 +101,21 @@ namespace GaussianSplatting.Runtime
                 m_kernelUpsweep = cs.FindKernel("Upsweep");
                 m_kernelScan = cs.FindKernel("Scan");
                 m_kernelDownsweep = cs.FindKernel("Downsweep");
+                m_kernelBuildIndirectArgs = cs.FindKernel("BuildIndirectArgs");
             }
 
             m_Valid = m_kernelInitDeviceRadixSort >= 0 &&
                       m_kernelUpsweep >= 0 &&
                       m_kernelScan >= 0 &&
-                      m_kernelDownsweep >= 0;
+                      m_kernelDownsweep >= 0 &&
+                      m_kernelBuildIndirectArgs >= 0;
             if (m_Valid)
             {
                 if (!cs.IsSupported(m_kernelInitDeviceRadixSort) ||
                     !cs.IsSupported(m_kernelUpsweep) ||
                     !cs.IsSupported(m_kernelScan) ||
-                    !cs.IsSupported(m_kernelDownsweep))
+                    !cs.IsSupported(m_kernelDownsweep) || 
+                    !cs.IsSupported(m_kernelBuildIndirectArgs))
                 {
                     m_Valid = false;
                 }
@@ -117,6 +126,8 @@ namespace GaussianSplatting.Runtime
             m_ascendKeyword = new LocalKeyword(cs, "SHOULD_ASCEND");
             m_sortPairKeyword = new LocalKeyword(cs, "SORT_PAIRS");
             m_vulkanKeyword = new LocalKeyword(cs, "VULKAN");
+
+            
 
             cs.EnableKeyword(m_keyUintKeyword);
             cs.EnableKeyword(m_payloadUintKeyword);
@@ -130,16 +141,7 @@ namespace GaussianSplatting.Runtime
 
         static uint DivRoundUp(uint x, uint y) => (x + y - 1) / y;
 
-        //Can we remove the last 4 padding without breaking?
-        struct SortConstants
-        {
-            public uint numKeys;                        // The number of keys to sort
-            public uint radixShift;                     // The radix shift value for the current pass
-            public uint threadBlocks;                   // threadBlocks
-            public uint padding0;                       // Padding - unused
-        }
-
-        public void Dispatch(CommandBuffer cmd, Args args)
+        public void DispatchIndirect(CommandBuffer cmd, Args args, GraphicsBuffer sortCountBuffer)
         {
             Assert.IsTrue(Valid);
 
@@ -148,82 +150,28 @@ namespace GaussianSplatting.Runtime
             GraphicsBuffer dstKeyBuffer = args.resources.altBuffer;
             GraphicsBuffer dstPayloadBuffer = args.resources.altPayloadBuffer;
 
-            SortConstants constants = default;
-            constants.numKeys = args.count;
-            constants.threadBlocks = DivRoundUp(args.count, DEVICE_RADIX_SORT_PARTITION_SIZE);
-
-            // Setup overall constants
-            cmd.SetComputeIntParam(m_CS, "e_numKeys", (int)constants.numKeys);
-            cmd.SetComputeIntParam(m_CS, "e_threadBlocks", (int)constants.threadBlocks);
-
-            //Set statically located buffers
-            //Upsweep
-            cmd.SetComputeBufferParam(m_CS, m_kernelUpsweep, "b_passHist", args.resources.passHistBuffer);
-            cmd.SetComputeBufferParam(m_CS, m_kernelUpsweep, "b_globalHist", args.resources.globalHistBuffer);
-
-            //Scan
-            cmd.SetComputeBufferParam(m_CS, m_kernelScan, "b_passHist", args.resources.passHistBuffer);
-
-            //Downsweep
-            cmd.SetComputeBufferParam(m_CS, m_kernelDownsweep, "b_passHist", args.resources.passHistBuffer);
-            cmd.SetComputeBufferParam(m_CS, m_kernelDownsweep, "b_globalHist", args.resources.globalHistBuffer);
-
-            //Clear the global histogram
-            cmd.SetComputeBufferParam(m_CS, m_kernelInitDeviceRadixSort, "b_globalHist", args.resources.globalHistBuffer);
-            cmd.DispatchCompute(m_CS, m_kernelInitDeviceRadixSort, 1, 1, 1);
-
-            // Execute the sort algorithm in 8-bit increments
-            for (constants.radixShift = 0; constants.radixShift < 32; constants.radixShift += DEVICE_RADIX_SORT_BITS)
-            {
-                cmd.SetComputeIntParam(m_CS, "e_radixShift", (int)constants.radixShift);
-
-                //Upsweep
-                cmd.SetComputeBufferParam(m_CS, m_kernelUpsweep, "b_sort", srcKeyBuffer);
-                cmd.DispatchCompute(m_CS, m_kernelUpsweep, (int)constants.threadBlocks, 1, 1);
-
-                // Scan
-                cmd.DispatchCompute(m_CS, m_kernelScan, (int)DEVICE_RADIX_SORT_RADIX, 1, 1);
-
-                // Downsweep
-                cmd.SetComputeBufferParam(m_CS, m_kernelDownsweep, "b_sort", srcKeyBuffer);
-                cmd.SetComputeBufferParam(m_CS, m_kernelDownsweep, "b_sortPayload", srcPayloadBuffer);
-                cmd.SetComputeBufferParam(m_CS, m_kernelDownsweep, "b_alt", dstKeyBuffer);
-                cmd.SetComputeBufferParam(m_CS, m_kernelDownsweep, "b_altPayload", dstPayloadBuffer);
-                cmd.DispatchCompute(m_CS, m_kernelDownsweep, (int)constants.threadBlocks, 1, 1);
-
-                // Swap
-                (srcKeyBuffer, dstKeyBuffer) = (dstKeyBuffer, srcKeyBuffer);
-                (srcPayloadBuffer, dstPayloadBuffer) = (dstPayloadBuffer, srcPayloadBuffer);
-            }
-        }
-
-        public void DispatchIndirectCount(CommandBuffer cmd, Args args, GraphicsBuffer sortCountBuffer)
-        {
-            Assert.IsTrue(Valid);
-
-            GraphicsBuffer srcKeyBuffer = args.inputKeys;
-            GraphicsBuffer srcPayloadBuffer = args.inputValues;
-            GraphicsBuffer dstKeyBuffer = args.resources.altBuffer;
-            GraphicsBuffer dstPayloadBuffer = args.resources.altPayloadBuffer;
-
-            // We still dispatch for the MAX capacity (args.count), resources were allocated for that.
             uint maxCount = args.count;
             uint maxThreadBlocks = DivRoundUp(maxCount, DEVICE_RADIX_SORT_PARTITION_SIZE);
 
-            // Keep these as MAX; shader will clamp to b_sortCount for real work.
-            cmd.SetComputeIntParam(m_CS, "e_numKeys", (int)maxCount);
+            // Keep max width for histogram layout.
+            //cmd.SetComputeIntParam(m_CS, "e_numKeys", (int)maxCount);
             cmd.SetComputeIntParam(m_CS, "e_threadBlocks", (int)maxThreadBlocks);
 
-            // Bind the GPU count buffer to every kernel that needs numKeys/partial behavior
+            // --- Build indirect args on GPU ---
+            cmd.SetComputeBufferParam(m_CS, m_kernelBuildIndirectArgs, "b_sortCount", sortCountBuffer);
+            cmd.SetComputeBufferParam(m_CS, m_kernelBuildIndirectArgs, "b_dispatchArgs", args.resources.dispatchArgs);
+            cmd.DispatchCompute(m_CS, m_kernelBuildIndirectArgs, 1, 1, 1);
+
+            // Bind size buffers to the kernels
+            cmd.SetComputeBufferParam(m_CS, m_kernelScan, "b_dispatchArgs", args.resources.dispatchArgs);
             cmd.SetComputeBufferParam(m_CS, m_kernelUpsweep,   "b_sortCount", sortCountBuffer);
-            cmd.SetComputeBufferParam(m_CS, m_kernelScan,      "b_sortCount", sortCountBuffer);
             cmd.SetComputeBufferParam(m_CS, m_kernelDownsweep, "b_sortCount", sortCountBuffer);
 
-            // Static buffers
-            cmd.SetComputeBufferParam(m_CS, m_kernelUpsweep, "b_passHist", args.resources.passHistBuffer);
-            cmd.SetComputeBufferParam(m_CS, m_kernelUpsweep, "b_globalHist", args.resources.globalHistBuffer);
+            // Static buffers for sort kernels
+            cmd.SetComputeBufferParam(m_CS, m_kernelUpsweep,   "b_passHist", args.resources.passHistBuffer);
+            cmd.SetComputeBufferParam(m_CS, m_kernelUpsweep,   "b_globalHist", args.resources.globalHistBuffer);
 
-            cmd.SetComputeBufferParam(m_CS, m_kernelScan, "b_passHist", args.resources.passHistBuffer);
+            cmd.SetComputeBufferParam(m_CS, m_kernelScan,      "b_passHist", args.resources.passHistBuffer);
 
             cmd.SetComputeBufferParam(m_CS, m_kernelDownsweep, "b_passHist", args.resources.passHistBuffer);
             cmd.SetComputeBufferParam(m_CS, m_kernelDownsweep, "b_globalHist", args.resources.globalHistBuffer);
@@ -232,30 +180,31 @@ namespace GaussianSplatting.Runtime
             cmd.SetComputeBufferParam(m_CS, m_kernelInitDeviceRadixSort, "b_globalHist", args.resources.globalHistBuffer);
             cmd.DispatchCompute(m_CS, m_kernelInitDeviceRadixSort, 1, 1, 1);
 
-            // 4 passes
+            // Execute the sort algorithm in 8-bit increments
             for (uint radixShift = 0; radixShift < 32; radixShift += DEVICE_RADIX_SORT_BITS)
             {
                 cmd.SetComputeIntParam(m_CS, "e_radixShift", (int)radixShift);
 
-                // Upsweep (dispatch MAX blocks; shader clamps via b_sortCount)
+                // Upsweep (INDIRECT)
                 cmd.SetComputeBufferParam(m_CS, m_kernelUpsweep, "b_sort", srcKeyBuffer);
-                cmd.DispatchCompute(m_CS, m_kernelUpsweep, (int)maxThreadBlocks, 1, 1);
+                cmd.DispatchCompute(m_CS, m_kernelUpsweep, args.resources.dispatchArgs, 0);
 
-                // Scan is fixed size
+                // Scan (fixed 256 groups)
                 cmd.DispatchCompute(m_CS, m_kernelScan, (int)DEVICE_RADIX_SORT_RADIX, 1, 1);
 
-                // Downsweep (dispatch MAX blocks; shader early-outs gid>=activeBlocks)
+                // Downsweep (INDIRECT)
                 cmd.SetComputeBufferParam(m_CS, m_kernelDownsweep, "b_sort", srcKeyBuffer);
                 cmd.SetComputeBufferParam(m_CS, m_kernelDownsweep, "b_sortPayload", srcPayloadBuffer);
                 cmd.SetComputeBufferParam(m_CS, m_kernelDownsweep, "b_alt", dstKeyBuffer);
                 cmd.SetComputeBufferParam(m_CS, m_kernelDownsweep, "b_altPayload", dstPayloadBuffer);
-                cmd.DispatchCompute(m_CS, m_kernelDownsweep, (int)maxThreadBlocks, 1, 1);
+                cmd.DispatchCompute(m_CS, m_kernelDownsweep, args.resources.dispatchArgs, 0);
 
                 // Swap
                 (srcKeyBuffer, dstKeyBuffer) = (dstKeyBuffer, srcKeyBuffer);
                 (srcPayloadBuffer, dstPayloadBuffer) = (dstPayloadBuffer, srcPayloadBuffer);
             }
         }
+
 
     }
 }

--- a/package/Runtime/GpuSorting.cs
+++ b/package/Runtime/GpuSorting.cs
@@ -154,7 +154,7 @@ namespace GaussianSplatting.Runtime
             uint maxThreadBlocks = DivRoundUp(maxCount, DEVICE_RADIX_SORT_PARTITION_SIZE);
 
             // Keep max width for histogram layout.
-            //cmd.SetComputeIntParam(m_CS, "e_numKeys", (int)maxCount);
+            cmd.SetComputeIntParam(m_CS, "e_numKeys", (int)maxCount);
             cmd.SetComputeIntParam(m_CS, "e_threadBlocks", (int)maxThreadBlocks);
 
             // --- Build indirect args on GPU ---

--- a/package/Shaders/DeviceRadixSort.hlsl
+++ b/package/Shaders/DeviceRadixSort.hlsl
@@ -186,9 +186,19 @@ void Upsweep(uint3 gtid : SV_GroupThreadID, uint3 gid : SV_GroupID)
         GlobalHistExclusiveScanWLT16(gtid.x, waveSize);
 }
 
+// 12 bytes: uint3 { groupsX, groupsY, groupsZ }
+RWByteAddressBuffer b_dispatchArgs;
+
 //*****************************************************************************
 //SCAN KERNEL
 //*****************************************************************************
+//
+// indirect dispatch:
+// - activeBlocks = number of valid columns in b_passHist for this sort call.
+// - b_passHist layout stride remains e_threadBlocks (max), so deviceOffset uses e_threadBlocks.
+// - Only scan [0..activeBlocks) columns to avoid work when activeBlocks << e_threadBlocks.
+//
+
 inline void ExclusiveThreadBlockScanFullWGE16(
     uint gtid,
     uint laneMask,
@@ -203,14 +213,14 @@ inline void ExclusiveThreadBlockScanFullWGE16(
         g_scan[gtid] = b_passHist[i + deviceOffset];
         g_scan[gtid] += WavePrefixSum(g_scan[gtid]);
         GroupMemoryBarrierWithGroupSync();
-            
+
         if (gtid < SCAN_DIM / waveSize)
         {
             g_scan[(gtid + 1) * waveSize - 1] +=
                 WavePrefixSum(g_scan[(gtid + 1) * waveSize - 1]);
         }
         GroupMemoryBarrierWithGroupSync();
-        
+
         uint t = (WaveGetLaneIndex() != laneMask ? g_scan[gtid] : 0) + reduction;
         if (gtid >= waveSize)
             t += WaveReadLaneAt(g_scan[gtid - 1], 0);
@@ -228,23 +238,28 @@ inline void ExclusiveThreadBlockScanPartialWGE16(
     uint partEnd,
     uint deviceOffset,
     uint waveSize,
-    uint reduction)
+    uint reduction,
+    uint activeBlocks)
 {
     uint i = gtid + partEnd;
-    if (i < e_threadBlocks)
-        g_scan[gtid] = b_passHist[deviceOffset + i];
+
+    uint v = 0;
+    if (i < activeBlocks)
+        v = b_passHist[deviceOffset + i];
+
+    g_scan[gtid] = v;
     g_scan[gtid] += WavePrefixSum(g_scan[gtid]);
     GroupMemoryBarrierWithGroupSync();
-            
+
     if (gtid < SCAN_DIM / waveSize)
     {
         g_scan[(gtid + 1) * waveSize - 1] +=
             WavePrefixSum(g_scan[(gtid + 1) * waveSize - 1]);
     }
     GroupMemoryBarrierWithGroupSync();
-        
+
     const uint index = circularLaneShift + (i & ~laneMask);
-    if (index < e_threadBlocks)
+    if (index < activeBlocks)
     {
         uint t = (WaveGetLaneIndex() != laneMask ? g_scan[gtid] : 0) + reduction;
         if (gtid >= waveSize)
@@ -253,14 +268,15 @@ inline void ExclusiveThreadBlockScanPartialWGE16(
     }
 }
 
-inline void ExclusiveThreadBlockScanWGE16(uint gtid, uint gid, uint waveSize)
+inline void ExclusiveThreadBlockScanWGE16(uint gtid, uint gid, uint waveSize, uint activeBlocks)
 {
     uint reduction = 0;
     const uint laneMask = waveSize - 1;
     const uint circularLaneShift = WaveGetLaneIndex() + 1 & laneMask;
-    const uint partionsEnd = e_threadBlocks / SCAN_DIM * SCAN_DIM;
+
+    const uint partionsEnd = (activeBlocks / SCAN_DIM) * SCAN_DIM;
     const uint deviceOffset = gid * e_threadBlocks;
-    
+
     ExclusiveThreadBlockScanFullWGE16(
         gtid,
         laneMask,
@@ -270,14 +286,18 @@ inline void ExclusiveThreadBlockScanWGE16(uint gtid, uint gid, uint waveSize)
         waveSize,
         reduction);
 
-    ExclusiveThreadBlockScanPartialWGE16(
-        gtid,
-        laneMask,
-        circularLaneShift,
-        partionsEnd,
-        deviceOffset,
-        waveSize,
-        reduction);
+    if (partionsEnd < activeBlocks)
+    {
+        ExclusiveThreadBlockScanPartialWGE16(
+            gtid,
+            laneMask,
+            circularLaneShift,
+            partionsEnd,
+            deviceOffset,
+            waveSize,
+            reduction,
+            activeBlocks);
+    }
 }
 
 inline void ExclusiveThreadBlockScanFullWLT16(
@@ -299,7 +319,7 @@ inline void ExclusiveThreadBlockScanFullWLT16(
             b_passHist[circularLaneShift + k * SCAN_DIM + deviceOffset] =
                 (circularLaneShift ? g_scan[gtid] : 0) + reduction;
         }
-            
+
         uint offset = laneLog;
         uint j = waveSize;
         for (; j < (SCAN_DIM >> 1); j <<= laneLog)
@@ -310,7 +330,7 @@ inline void ExclusiveThreadBlockScanFullWLT16(
                     WavePrefixSum(g_scan[((gtid + 1) << offset) - 1]);
             }
             GroupMemoryBarrierWithGroupSync();
-            
+
             if ((gtid & ((j << laneLog) - 1)) >= j)
             {
                 if (gtid < (j << laneLog))
@@ -331,15 +351,15 @@ inline void ExclusiveThreadBlockScanFullWLT16(
             offset += laneLog;
         }
         GroupMemoryBarrierWithGroupSync();
-        
-        //If SCAN_DIM is not a power of lanecount
+
+        // If SCAN_DIM is not a power of lanecount
         for (uint i = gtid + j; i < SCAN_DIM; i += SCAN_DIM)
         {
             b_passHist[i + k * SCAN_DIM + deviceOffset] =
                 WaveReadLaneAt(g_scan[((i >> offset) << offset) - 1], 0) +
                 ((i & (j - 1)) ? g_scan[i - 1] : 0) + reduction;
         }
-            
+
         reduction += WaveReadLaneAt(g_scan[SCAN_DIM - 1], 0) +
             WaveReadLaneAt(g_scan[(((SCAN_DIM - 1) >> offset) << offset) - 1], 0);
         GroupMemoryBarrierWithGroupSync();
@@ -353,21 +373,28 @@ inline void ExclusiveThreadBlockScanParitalWLT16(
     uint laneLog,
     uint circularLaneShift,
     uint waveSize,
-    uint reduction)
+    uint reduction,
+    uint activeBlocks)
 {
-    const uint finalPartSize = e_threadBlocks - partitions * SCAN_DIM;
+    const uint finalPartSize = activeBlocks - partitions * SCAN_DIM;
+    if (finalPartSize == 0)
+        return;
+
+    // IMPORTANT: lanes outside remainder must be 0, otherwise WavePrefixSum sees garbage.
+    uint v = 0;
     if (gtid < finalPartSize)
-    {
-        g_scan[gtid] = b_passHist[gtid + partitions * SCAN_DIM + deviceOffset];
-        g_scan[gtid] += WavePrefixSum(g_scan[gtid]);
-    }
+        v = b_passHist[gtid + partitions * SCAN_DIM + deviceOffset];
+
+    g_scan[gtid] = v;
+    g_scan[gtid] += WavePrefixSum(g_scan[gtid]);
     GroupMemoryBarrierWithGroupSync();
+
     if (gtid < waveSize && circularLaneShift < finalPartSize)
     {
         b_passHist[circularLaneShift + partitions * SCAN_DIM + deviceOffset] =
             (circularLaneShift ? g_scan[gtid] : 0) + reduction;
     }
-        
+
     uint offset = laneLog;
     for (uint j = waveSize; j < finalPartSize; j <<= laneLog)
     {
@@ -377,7 +404,7 @@ inline void ExclusiveThreadBlockScanParitalWLT16(
                 WavePrefixSum(g_scan[((gtid + 1) << offset) - 1]);
         }
         GroupMemoryBarrierWithGroupSync();
-            
+
         if ((gtid & ((j << laneLog) - 1)) >= j && gtid < finalPartSize)
         {
             if (gtid < (j << laneLog))
@@ -399,14 +426,14 @@ inline void ExclusiveThreadBlockScanParitalWLT16(
     }
 }
 
-inline void ExclusiveThreadBlockScanWLT16(uint gtid, uint gid, uint waveSize)
+inline void ExclusiveThreadBlockScanWLT16(uint gtid, uint gid, uint waveSize, uint activeBlocks)
 {
     uint reduction = 0;
-    const uint partitions = e_threadBlocks / SCAN_DIM;
-    const uint deviceOffset = gid * e_threadBlocks;
+    const uint partitions = activeBlocks / SCAN_DIM;          // only full partitions we actually have
+    const uint deviceOffset = gid * e_threadBlocks;           // KEEP stride = max threadBlocks
     const uint laneLog = countbits(waveSize - 1);
     const uint circularLaneShift = WaveGetLaneIndex() + 1 & waveSize - 1;
-    
+
     ExclusiveThreadBlockScanFullWLT16(
         gtid,
         partitions,
@@ -415,28 +442,38 @@ inline void ExclusiveThreadBlockScanWLT16(uint gtid, uint gid, uint waveSize)
         circularLaneShift,
         waveSize,
         reduction);
-    
-    ExclusiveThreadBlockScanParitalWLT16(
-        gtid,
-        partitions,
-        deviceOffset,
-        laneLog,
-        circularLaneShift,
-        waveSize,
-        reduction);
+
+    // Partial partition (only if remainder exists)
+    if (partitions * SCAN_DIM < activeBlocks)
+    {
+        ExclusiveThreadBlockScanParitalWLT16(
+            gtid,
+            partitions,
+            deviceOffset,
+            laneLog,
+            circularLaneShift,
+            waveSize,
+            reduction,
+            activeBlocks);
+    }
 }
 
-//Scan does not need flattening of gids
+// Scan does not need flattening of gids
 [numthreads(SCAN_DIM, 1, 1)]
 void Scan(uint3 gtid : SV_GroupThreadID, uint3 gid : SV_GroupID)
 {
     const uint waveSize = getWaveSize();
+
+    uint activeBlocks = b_dispatchArgs.Load(0);
+    activeBlocks = min(activeBlocks, e_threadBlocks);
+
     if (waveSize >= 16)
-        ExclusiveThreadBlockScanWGE16(gtid.x, gid.x, waveSize);
+        ExclusiveThreadBlockScanWGE16(gtid.x, gid.x, waveSize, activeBlocks);
 
     if (waveSize < 16)
-        ExclusiveThreadBlockScanWLT16(gtid.x, gid.x, waveSize);
+        ExclusiveThreadBlockScanWLT16(gtid.x, gid.x, waveSize, activeBlocks);
 }
+
 
 //*****************************************************************************
 //DOWNSWEEP KERNEL
@@ -538,3 +575,21 @@ void Downsweep(uint3 gtid : SV_GroupThreadID, uint3 gid : SV_GroupID)
     else
         ScatterDevicePartial(gtid.x, waveSize, gid.x, offsets);
 }
+
+
+
+
+// Build dispatch args based on GPU-written key count (b_sortCount.Load(0)).
+[numthreads(1, 1, 1)]
+void BuildIndirectArgs(uint3 id : SV_DispatchThreadID)
+{
+    uint numKeys = GetActiveNumKeys();
+    uint blocks = (numKeys + PART_SIZE - 1) / PART_SIZE;
+
+    blocks = clamp(blocks, 1u, e_threadBlocks);
+
+    b_dispatchArgs.Store(0, blocks);
+    b_dispatchArgs.Store(4, 1u);
+    b_dispatchArgs.Store(8, 1u);
+}
+

--- a/package/Shaders/DeviceRadixSort.hlsl
+++ b/package/Shaders/DeviceRadixSort.hlsl
@@ -52,9 +52,11 @@ void InitDeviceRadixSort(int3 id : SV_DispatchThreadID)
 inline void HistogramDigitCounts(uint gtid, uint gid)
 {
     const uint histOffset = gtid / 64 * RADIX;
-    const uint partitionEnd = gid == e_threadBlocks - 1 ?
-        e_numKeys : (gid + 1) * PART_SIZE;
-    for (uint i = gtid + gid * PART_SIZE; i < partitionEnd; i += US_DIM)
+    uint numKeys = GetActiveNumKeys();
+    uint partitionStart = gid * PART_SIZE;
+    uint partitionEnd   = min(numKeys, (gid + 1) * PART_SIZE);
+
+    for (uint i = gtid + partitionStart; i < partitionEnd; i += US_DIM)
     {
 #if defined(KEY_UINT)
         InterlockedAdd(g_us[ExtractDigit(b_sort[i]) + histOffset], 1);
@@ -451,6 +453,15 @@ inline void LoadThreadBlockReductions(uint gtid, uint gid, uint exclusiveHistRed
 [numthreads(D_DIM, 1, 1)]
 void Downsweep(uint3 gtid : SV_GroupThreadID, uint3 gid : SV_GroupID)
 {
+
+    uint numKeys = GetActiveNumKeys();
+    uint activeBlocks = (numKeys + PART_SIZE - 1) / PART_SIZE;
+
+    if (gid.x >= activeBlocks)
+        return;
+
+    bool isLastActive = (gid.x == activeBlocks - 1);
+
     KeyStruct keys;
     OffsetStruct offsets;
     const uint waveSize = getWaveSize();
@@ -458,20 +469,19 @@ void Downsweep(uint3 gtid : SV_GroupThreadID, uint3 gid : SV_GroupID)
     ClearWaveHists(gtid.x, waveSize);
     GroupMemoryBarrierWithGroupSync();
     
-    if (gid.x < e_threadBlocks - 1)
+    if (!isLastActive)
     {
         if (waveSize >= 16)
             keys = LoadKeysWGE16(gtid.x, waveSize, gid.x);
-        
+
         if (waveSize < 16)
             keys = LoadKeysWLT16(gtid.x, waveSize, gid.x, SerialIterations(waveSize));
     }
-        
-    if (gid.x == e_threadBlocks - 1)
+    else
     {
         if (waveSize >= 16)
             keys = LoadKeysPartialWGE16(gtid.x, waveSize, gid.x);
-        
+
         if (waveSize < 16)
             keys = LoadKeysPartialWLT16(gtid.x, waveSize, gid.x, SerialIterations(waveSize));
     }
@@ -523,9 +533,8 @@ void Downsweep(uint3 gtid : SV_GroupThreadID, uint3 gid : SV_GroupID)
     LoadThreadBlockReductions(gtid.x, gid.x, exclusiveHistReduction);
     GroupMemoryBarrierWithGroupSync();
     
-    if (gid.x < e_threadBlocks - 1)
+    if (!isLastActive)
         ScatterDevice(gtid.x, waveSize, gid.x, offsets);
-        
-    if (gid.x == e_threadBlocks - 1)
+    else
         ScatterDevicePartial(gtid.x, waveSize, gid.x, offsets);
 }

--- a/package/Shaders/SortCommon.hlsl
+++ b/package/Shaders/SortCommon.hlsl
@@ -91,6 +91,7 @@ struct DigitStruct
 #endif
 };
 
+// number of active keys to sort in the dispatch
 ByteAddressBuffer b_sortCount;
 
 uint GetActiveNumKeys()

--- a/package/Shaders/SortCommon.hlsl
+++ b/package/Shaders/SortCommon.hlsl
@@ -91,6 +91,13 @@ struct DigitStruct
 #endif
 };
 
+ByteAddressBuffer b_sortCount;
+
+uint GetActiveNumKeys()
+{
+    return b_sortCount.Load(0);
+}
+
 //*****************************************************************************
 //HELPER FUNCTIONS
 //*****************************************************************************
@@ -280,7 +287,7 @@ inline KeyStruct LoadKeysPartialWGE16(uint gtid, uint waveSize, uint partIndex)
         i < KEYS_PER_THREAD;
         ++i, t += waveSize)
     {
-        if (t < e_numKeys)
+        if (t < GetActiveNumKeys())
             LoadKey(keys.k[i], t);
         else
             LoadDummyKey(keys.k[i]);
@@ -296,7 +303,7 @@ inline KeyStruct LoadKeysPartialWLT16(uint gtid, uint waveSize, uint partIndex, 
         i < KEYS_PER_THREAD;
         ++i, t += waveSize * serialIterations)
     {
-        if (t < e_numKeys)
+        if (t < GetActiveNumKeys())
             LoadKey(keys.k[i], t);
         else
             LoadDummyKey(keys.k[i]);
@@ -565,7 +572,7 @@ inline void ScatterKeysShared(OffsetStruct offsets, KeyStruct keys)
 
 inline uint DescendingIndex(uint deviceIndex)
 {
-    return e_numKeys - deviceIndex - 1;
+    return GetActiveNumKeys() - deviceIndex - 1;
 }
 
 inline void WriteKey(uint deviceIndex, uint groupSharedIndex)
@@ -797,7 +804,7 @@ inline void ScatterKeysOnlyDevicePartialDescending(uint gtid, uint finalPartSize
 
 inline void ScatterKeysOnlyDevicePartial(uint gtid, uint partIndex)
 {
-    const uint finalPartSize = e_numKeys - partIndex * PART_SIZE;
+    const uint finalPartSize = GetActiveNumKeys() - partIndex * PART_SIZE;
 #if defined(SHOULD_ASCEND)
     ScatterKeysOnlyDevicePartialAscending(gtid, finalPartSize);
 #else
@@ -856,7 +863,7 @@ inline void LoadPayloadsPartialWGE16(
         i < KEYS_PER_THREAD;
         ++i, t += waveSize)
     {
-        if (t < e_numKeys)
+        if (t < GetActiveNumKeys())
             LoadPayload(payloads.k[i], t);
     }
 }
@@ -873,7 +880,7 @@ inline void LoadPayloadsPartialWLT16(
         i < KEYS_PER_THREAD;
         ++i, t += waveSize * serialIterations)
     {
-        if (t < e_numKeys)
+        if (t < GetActiveNumKeys())
             LoadPayload(payloads.k[i], t);
     }
 }
@@ -918,7 +925,7 @@ inline void ScatterPairsDevicePartial(
     OffsetStruct offsets)
 {
     DigitStruct digits;
-    const uint finalPartSize = e_numKeys - partIndex * PART_SIZE;
+    const uint finalPartSize = GetActiveNumKeys() - partIndex * PART_SIZE;
 #if defined(SHOULD_ASCEND)
     ScatterPairsKeyPhaseAscendingPartial(gtid, finalPartSize, digits);
 #else

--- a/package/Shaders/SortCommon.hlsl
+++ b/package/Shaders/SortCommon.hlsl
@@ -95,7 +95,7 @@ ByteAddressBuffer b_sortCount;
 
 uint GetActiveNumKeys()
 {
-    return b_sortCount.Load(0);
+    return min(b_sortCount.Load(0), e_numKeys);
 }
 
 //*****************************************************************************

--- a/package/Shaders/SplatUtilities.compute
+++ b/package/Shaders/SplatUtilities.compute
@@ -33,7 +33,6 @@
 #pragma kernel Scan
 #pragma kernel Downsweep
 #pragma kernel BuildIndirectArgs
-//#pragma kernel ClearPassHist
 
 // GPU sorting needs wave ops
 #pragma require wavebasic

--- a/package/Shaders/SplatUtilities.compute
+++ b/package/Shaders/SplatUtilities.compute
@@ -1,9 +1,13 @@
 // SPDX-License-Identifier: MIT
+
 #define GROUP_SIZE 1024
 
 #pragma kernel CSSetIndices
+#pragma kernel CSBuildIndirectArgs
 #pragma kernel CSCalcDistances
 #pragma kernel CSCalcViewData
+#pragma kernel CSClearVisibleKeyCount
+#pragma kernel CSCullFrustum
 #pragma kernel CSUpdateEditData
 #pragma kernel CSInitEditData
 #pragma kernel CSClearBuffer
@@ -23,6 +27,7 @@
 #pragma multi_compile __ SHOULD_ASCEND
 #pragma multi_compile __ SORT_PAIRS
 #pragma multi_compile __ VULKAN
+
 #pragma kernel InitDeviceRadixSort
 #pragma kernel Upsweep
 #pragma kernel Scan
@@ -46,6 +51,7 @@ int _SelectionMode;
 
 RWStructuredBuffer<uint> _SplatSortDistances;
 RWStructuredBuffer<uint> _SplatSortKeys;
+RWByteAddressBuffer _VisibleKeyCount;
 uint _SplatCount;
 
 // radix sort etc. friendly, see http://stereopsis.com/radix.html
@@ -56,38 +62,70 @@ uint FloatToSortableUint(float f)
     return fu ^ mask;
 }
 
-[numthreads(GROUP_SIZE,1,1)]
-void CSSetIndices (uint3 id : SV_DispatchThreadID)
+[numthreads(GROUP_SIZE, 1, 1)]
+void CSSetIndices(uint3 id : SV_DispatchThreadID)
 {
     uint idx = id.x;
-    if (idx >= _SplatCount)
-        return;
-
+    if (idx >= _SplatCount) return;
     _SplatSortKeys[idx] = idx;
 }
 
-[numthreads(GROUP_SIZE,1,1)]
-void CSCalcDistances (uint3 id : SV_DispatchThreadID)
+RWByteAddressBuffer _ArgsDispatchVisible; // 3 uints: {x,y,z}
+RWByteAddressBuffer _ArgsDrawQuad;        // 5 uints: indexed draw args (6 indices)
+RWByteAddressBuffer _ArgsDrawCube;        // 5 uints: indexed draw args (36 indices)
+
+[numthreads(1, 1, 1)]
+void CSBuildIndirectArgs(uint3 id : SV_DispatchThreadID)
 {
-    uint idx = id.x;
-    if (idx >= _SplatCount)
-        return;
+    uint n = _VisibleKeyCount.Load(0);
+    n = min(n, _SplatCount);
+    uint groupsX = (n + GROUP_SIZE - 1) / GROUP_SIZE;
 
-    uint origIdx = _SplatSortKeys[idx];
+    _ArgsDispatchVisible.Store(0, groupsX);
+    _ArgsDispatchVisible.Store(4, 1);
+    _ArgsDispatchVisible.Store(8, 1);
 
+    // --- Indexed draw args layout ---
+    // [0] indexCountPerInstance
+    // [1] instanceCount
+    // [2] startIndexLocation
+    // [3] baseVertexLocation
+    // [4] startInstanceLocation
+
+    // Quad (6 indices)
+    _ArgsDrawQuad.Store(0, 6);
+    _ArgsDrawQuad.Store(4, n);
+    _ArgsDrawQuad.Store(8, 0);
+    _ArgsDrawQuad.Store(12, 0);
+    _ArgsDrawQuad.Store(16, 0);
+
+    // Cube (36 indices)
+    _ArgsDrawCube.Store(0, 36);
+    _ArgsDrawCube.Store(4, n);
+    _ArgsDrawCube.Store(8, 0);
+    _ArgsDrawCube.Store(12, 0);
+    _ArgsDrawCube.Store(16, 0);
+}
+
+[numthreads(GROUP_SIZE, 1, 1)]
+void CSCalcDistances(uint3 id : SV_DispatchThreadID)
+{
+    uint visIdx = id.x;
+    uint n = _VisibleKeyCount.Load(0);
+    n = min(n, _SplatCount);
+    if (visIdx >= n) return;
+
+    uint origIdx = _SplatSortKeys[visIdx];
     float3 pos = LoadSplatPos(origIdx);
-    pos = mul(_MatrixMV, float4(pos.xyz, 1)).xyz;
-
-    _SplatSortDistances[idx] = FloatToSortableUint(pos.z);
+    pos = mul(_MatrixMV, float4(pos, 1)).xyz;
+    _SplatSortDistances[visIdx] = FloatToSortableUint(pos.z);
 }
 
 RWStructuredBuffer<SplatViewData> _SplatViewData;
-
 float _SplatScale;
 float _SplatOpacityScale;
 uint _SHOrder;
 uint _SHOnly;
-
 uint _SplatCutoutsCount;
 
 #define SPLAT_CUTOUT_TYPE_ELLIPSOID 0
@@ -98,6 +136,7 @@ struct GaussianCutoutShaderData // match GaussianCutout.ShaderData in C#
     float4x4 mat;
     uint typeAndFlags;
 };
+
 StructuredBuffer<GaussianCutoutShaderData> _SplatCutouts;
 
 RWByteAddressBuffer _SplatSelectedBits;
@@ -106,8 +145,8 @@ uint _SplatBitsValid;
 
 void DecomposeCovariance(float3 cov2d, out float2 v1, out float2 v2)
 {
-    #if 0 // does not quite give the correct results?
-
+#if 0
+    // does not quite give the correct results?
     // https://jsfiddle.net/mattrossman/ehxmtgw6/
     // References:
     // - https://www.youtube.com/watch?v=e50Bj7jn9IQ
@@ -118,21 +157,22 @@ void DecomposeCovariance(float3 cov2d, out float2 v1, out float2 v2)
     float d = cov2d.z;
     float det = a * d - b * b; // matrix is symmetric, so "c" is same as "b"
     float trace = a + d;
-
     float mean = 0.5 * trace;
     float dist = sqrt(mean * mean - det);
-
     float lambda1 = mean + dist; // 1st eigenvalue
     float lambda2 = mean - dist; // 2nd eigenvalue
 
-    if (b == 0) {
+    if (b == 0)
+    {
         // https://twitter.com/the_ross_man/status/1706342719776551360
         if (a > d) v1 = float2(1, 0);
         else v1 = float2(0, 1);
-    } else
+    }
+    else
         v1 = normalize(float2(b, d - lambda2));
 
     v1.y = -v1.y;
+
     // The 2nd eigenvector is just a 90 degree rotation of the first since Gaussian axes are orthogonal
     v2 = float2(v1.y, -v1.x);
 
@@ -143,9 +183,7 @@ void DecomposeCovariance(float3 cov2d, out float2 v1, out float2 v2)
     float radius = 1.5;
     v1 *= radius;
     v2 *= radius;
-
-    #else
-
+#else
     // same as in antimatter15/splat
     float diag1 = cov2d.x, diag2 = cov2d.z, offDiag = cov2d.y;
     float mid = 0.5f * (diag1 + diag2);
@@ -154,11 +192,11 @@ void DecomposeCovariance(float3 cov2d, out float2 v1, out float2 v2)
     float lambda2 = max(mid - radius, 0.1);
     float2 diagVec = normalize(float2(offDiag, lambda1 - diag1));
     diagVec.y = -diagVec.y;
+
     float maxSize = 4096.0;
     v1 = min(sqrt(2.0 * lambda1), maxSize) * diagVec;
     v2 = min(sqrt(2.0 * lambda2), maxSize) * float2(diagVec.y, -diagVec.x);
-
-    #endif
+#endif
 }
 
 bool IsSplatCut(float3 pos)
@@ -170,9 +208,10 @@ bool IsSplatCut(float3 pos)
         uint type = cutData.typeAndFlags & 0xFF;
         if (type == 0xFF) // invalid/null cutout, ignore
             continue;
-        bool invert = (cutData.typeAndFlags & 0xFF00) != 0;
 
+        bool invert = (cutData.typeAndFlags & 0xFF00) != 0;
         float3 cutoutPos = mul(cutData.mat, float4(pos, 1)).xyz;
+
         if (type == SPLAT_CUTOUT_TYPE_ELLIPSOID)
         {
             if (dot(cutoutPos, cutoutPos) <= 1) return invert;
@@ -186,18 +225,21 @@ bool IsSplatCut(float3 pos)
     return finalCut;
 }
 
-[numthreads(GROUP_SIZE,1,1)]
-void CSCalcViewData (uint3 id : SV_DispatchThreadID)
+[numthreads(GROUP_SIZE, 1, 1)]
+void CSCalcViewData(uint3 id : SV_DispatchThreadID)
 {
-    uint idx = id.x;
-    if (idx >= _SplatCount)
-        return;
+    uint visIdx = id.x;
+    uint n = _VisibleKeyCount.Load(0);
+    n = min(n, _SplatCount);
+    if (visIdx >= n) return;
 
+    uint idx = _SplatSortKeys[visIdx];
     SplatData splat = LoadSplatData(idx);
     SplatViewData view = (SplatViewData)0;
-    
-    float3 centerWorldPos = mul(_MatrixObjectToWorld, float4(splat.pos,1)).xyz;
+
+    float3 centerWorldPos = mul(_MatrixObjectToWorld, float4(splat.pos, 1)).xyz;
     float4 centerClipPos = mul(UNITY_MATRIX_VP, float4(centerWorldPos, 1));
+
     half opacityScale = _SplatOpacityScale;
     float splatScale = _SplatScale;
 
@@ -207,34 +249,33 @@ void CSCalcViewData (uint3 id : SV_DispatchThreadID)
         uint wordIdx = idx / 32;
         uint bitIdx = idx & 31;
         uint wordVal = _SplatDeletedBits.Load(wordIdx * 4);
-        if (wordVal & (1 << bitIdx))
-        {
+        if (wordVal & (1u << bitIdx))
             centerClipPos.w = 0;
-        }
     }
 
     // cutouts
     if (IsSplatCut(splat.pos))
-    {
         centerClipPos.w = 0;
-    }
 
     view.pos = centerClipPos;
     bool behindCam = centerClipPos.w <= 0;
+
     if (!behindCam)
     {
         float4 boxRot = splat.rot;
         float3 boxSize = splat.scale;
-
         float3x3 splatRotScaleMat = CalcMatrixFromRotationScale(boxRot, boxSize);
 
         float3 cov3d0, cov3d1;
         CalcCovariance3D(splatRotScaleMat, cov3d0, cov3d1);
+
         float splatScale2 = splatScale * splatScale;
         cov3d0 *= splatScale2;
         cov3d1 *= splatScale2;
-        float3 cov2d = CalcCovariance2D(splat.pos, cov3d0, cov3d1, _MatrixMV, UNITY_MATRIX_P, _VecScreenParams);
-        
+
+        float3 cov2d = CalcCovariance2D(
+            splat.pos, cov3d0, cov3d1, _MatrixMV, UNITY_MATRIX_P, _VecScreenParams);
+
         DecomposeCovariance(cov2d, view.axis1, view.axis2);
 
         float3 worldViewDir = _VecWorldSpaceCameraPos.xyz - centerWorldPos;
@@ -244,13 +285,100 @@ void CSCalcViewData (uint3 id : SV_DispatchThreadID)
         half4 col;
         col.rgb = ShadeSH(splat.sh, objViewDir, _SHOrder, _SHOnly != 0);
         col.a = min(splat.opacity * opacityScale, 65000);
+
         view.color.x = (f32tof16(col.r) << 16) | f32tof16(col.g);
         view.color.y = (f32tof16(col.b) << 16) | f32tof16(col.a);
     }
-    
+
     _SplatViewData[idx] = view;
 }
 
+[numthreads(1, 1, 1)]
+void CSClearVisibleKeyCount(uint3 id : SV_DispatchThreadID)
+{
+    _VisibleKeyCount.Store(0, 0);
+}
+
+static const float kCullSigma = 2.0;
+static const float kCullMargin = 1.1;
+float _ObjectToWorldMaxAxisScale;
+
+[numthreads(GROUP_SIZE, 1, 1)]
+void CSCullFrustum(uint3 id : SV_DispatchThreadID)
+{
+    uint idx = id.x;
+    bool inRange = (idx < _SplatCount);
+    bool visible = false;
+
+    if (inRange)
+    {
+        visible = true;
+
+        // deleted?
+        if (_SplatBitsValid)
+        {
+            uint wordIdx = idx / 32;
+            uint bitIdx = idx & 31;
+            uint wordVal = _SplatDeletedBits.Load(wordIdx * 4);
+            if (wordVal & (1u << bitIdx))
+                visible = false;
+        }
+
+        // Load full splat (handles chunks + formats)
+        SplatData splat = LoadSplatData(idx);
+
+        // cutouts
+        if (visible && IsSplatCut(splat.pos))
+            visible = false;
+
+        if (visible)
+        {
+            float3 centerWorldPos = mul(_MatrixObjectToWorld, float4(splat.pos, 1)).xyz;
+            float4 clip = mul(UNITY_MATRIX_VP, float4(centerWorldPos, 1));
+
+            if (clip.w <= 0)
+            {
+                visible = false;
+            }
+            else
+            {
+                // Bounding sphere radius in world units (conservative)
+                float maxSc = max(splat.scale.x, max(splat.scale.y, splat.scale.z));
+                float rWorld = maxSc * _SplatScale * kCullSigma * _ObjectToWorldMaxAxisScale;
+
+                // Convert to clip padding (approx)
+                float padX = abs(UNITY_MATRIX_P[0][0]) * rWorld;
+                float padY = abs(UNITY_MATRIX_P[1][1]) * rWorld;
+
+                float m = max(kCullMargin, 1.0);
+                if (abs(clip.x) > (clip.w * m + padX) || abs(clip.y) > (clip.w * m + padY))
+                    visible = false;
+            }
+        }
+    }
+
+    // wave-compacted append
+    bool vote = inRange && visible;
+    uint waveCount = WaveActiveCountBits(vote);
+    uint wavePrefix = WavePrefixCountBits(vote);
+    uint base = 0;
+
+    if (WaveIsFirstLane() && waveCount > 0)
+    {
+        uint currCount;
+        _VisibleKeyCount.InterlockedAdd(0, waveCount, currCount);
+        base = currCount;
+    }
+
+    base = WaveReadLaneFirst(base);
+
+    if (vote)
+    {
+        uint outIdx = base + wavePrefix;
+        if (outIdx < _SplatCount)
+            _SplatSortKeys[outIdx] = idx;
+    }
+}
 
 RWByteAddressBuffer _DstBuffer;
 ByteAddressBuffer _SrcBuffer;
@@ -263,16 +391,16 @@ uint2 GetSplatIndicesFromWord(uint idx)
     return uint2(idxStart, idxEnd);
 }
 
-[numthreads(GROUP_SIZE,1,1)]
-void CSUpdateEditData (uint3 id : SV_DispatchThreadID)
+[numthreads(GROUP_SIZE, 1, 1)]
+void CSUpdateEditData(uint3 id : SV_DispatchThreadID)
 {
     uint idx = id.x;
-    if (idx >= _BufferSize)
-        return;
+    if (idx >= _BufferSize) return;
 
     uint valSel = _SplatSelectedBits.Load(idx * 4);
     uint valDel = _SplatDeletedBits.Load(idx * 4);
     valSel &= ~valDel; // don't count deleted splats as selected
+
     uint2 splatIndices = GetSplatIndicesFromWord(idx);
 
     // update selection bounds
@@ -280,21 +408,25 @@ void CSUpdateEditData (uint3 id : SV_DispatchThreadID)
     float3 bmax = -1.0e38;
     uint mask = 1;
     uint valCut = 0;
+
     for (uint sidx = splatIndices.x; sidx < splatIndices.y; ++sidx, mask <<= 1)
     {
         float3 spos = LoadSplatPos(sidx);
+
         // don't count cut splats as selected
         if (IsSplatCut(spos))
         {
             valSel &= ~mask;
             valCut |= mask;
         }
+
         if (valSel & mask)
         {
             bmin = min(bmin, spos);
             bmax = max(bmax, spos);
         }
     }
+
     valCut &= ~valDel; // don't count deleted splats as cut
 
     if (valSel != 0)
@@ -306,45 +438,49 @@ void CSUpdateEditData (uint3 id : SV_DispatchThreadID)
         _DstBuffer.InterlockedMax(28, FloatToSortableUint(bmax.y));
         _DstBuffer.InterlockedMax(32, FloatToSortableUint(bmax.z));
     }
+
     uint sumSel = countbits(valSel);
     uint sumDel = countbits(valDel);
     uint sumCut = countbits(valCut);
+
     _DstBuffer.InterlockedAdd(0, sumSel);
     _DstBuffer.InterlockedAdd(4, sumDel);
     _DstBuffer.InterlockedAdd(8, sumCut);
 }
 
-[numthreads(1,1,1)]
-void CSInitEditData (uint3 id : SV_DispatchThreadID)
+[numthreads(1, 1, 1)]
+void CSInitEditData(uint3 id : SV_DispatchThreadID)
 {
-    _DstBuffer.Store3(0, uint3(0,0,0)); // selected, deleted, cut counts
+    _DstBuffer.Store3(0, uint3(0, 0, 0)); // selected, deleted, cut counts
+
     uint initMin = FloatToSortableUint(1.0e38);
     uint initMax = FloatToSortableUint(-1.0e38);
+
     _DstBuffer.Store3(12, uint3(initMin, initMin, initMin));
     _DstBuffer.Store3(24, uint3(initMax, initMax, initMax));
 }
 
-[numthreads(GROUP_SIZE,1,1)]
-void CSClearBuffer (uint3 id : SV_DispatchThreadID)
+[numthreads(GROUP_SIZE, 1, 1)]
+void CSClearBuffer(uint3 id : SV_DispatchThreadID)
 {
     uint idx = id.x;
-    if (idx >= _BufferSize)
-        return;
+    if (idx >= _BufferSize) return;
     _DstBuffer.Store(idx * 4, 0);
 }
 
-[numthreads(GROUP_SIZE,1,1)]
-void CSInvertSelection (uint3 id : SV_DispatchThreadID)
+[numthreads(GROUP_SIZE, 1, 1)]
+void CSInvertSelection(uint3 id : SV_DispatchThreadID)
 {
     uint idx = id.x;
-    if (idx >= _BufferSize)
-        return;
+    if (idx >= _BufferSize) return;
+
     uint v = _DstBuffer.Load(idx * 4);
     v = ~v;
 
     // do not select splats that are cut
     uint2 splatIndices = GetSplatIndicesFromWord(idx);
     uint mask = 1;
+
     for (uint sidx = splatIndices.x; sidx < splatIndices.y; ++sidx, mask <<= 1)
     {
         float3 spos = LoadSplatPos(sidx);
@@ -355,17 +491,18 @@ void CSInvertSelection (uint3 id : SV_DispatchThreadID)
     _DstBuffer.Store(idx * 4, v);
 }
 
-[numthreads(GROUP_SIZE,1,1)]
-void CSSelectAll (uint3 id : SV_DispatchThreadID)
+[numthreads(GROUP_SIZE, 1, 1)]
+void CSSelectAll(uint3 id : SV_DispatchThreadID)
 {
     uint idx = id.x;
-    if (idx >= _BufferSize)
-        return;
+    if (idx >= _BufferSize) return;
+
     uint v = ~0;
 
     // do not select splats that are cut
     uint2 splatIndices = GetSplatIndicesFromWord(idx);
     uint mask = 1;
+
     for (uint sidx = splatIndices.x; sidx < splatIndices.y; ++sidx, mask <<= 1)
     {
         float3 spos = LoadSplatPos(sidx);
@@ -376,13 +513,12 @@ void CSSelectAll (uint3 id : SV_DispatchThreadID)
     _DstBuffer.Store(idx * 4, v);
 }
 
-
-[numthreads(GROUP_SIZE,1,1)]
-void CSOrBuffers (uint3 id : SV_DispatchThreadID)
+[numthreads(GROUP_SIZE, 1, 1)]
+void CSOrBuffers(uint3 id : SV_DispatchThreadID)
 {
     uint idx = id.x;
-    if (idx >= _BufferSize)
-        return;
+    if (idx >= _BufferSize) return;
+
     uint a = _SrcBuffer.Load(idx * 4);
     uint b = _DstBuffer.Load(idx * 4);
     _DstBuffer.Store(idx * 4, a | b);
@@ -390,32 +526,33 @@ void CSOrBuffers (uint3 id : SV_DispatchThreadID)
 
 float4 _SelectionRect;
 
-[numthreads(GROUP_SIZE,1,1)]
-void CSSelectionUpdate (uint3 id : SV_DispatchThreadID)
+[numthreads(GROUP_SIZE, 1, 1)]
+void CSSelectionUpdate(uint3 id : SV_DispatchThreadID)
 {
     uint idx = id.x;
-    if (idx >= _SplatCount)
-        return;
+    if (idx >= _SplatCount) return;
 
     float3 pos = LoadSplatPos(idx);
-    if (IsSplatCut(pos))
-        return;
+    if (IsSplatCut(pos)) return;
 
-    float3 centerWorldPos = mul(_MatrixObjectToWorld, float4(pos,1)).xyz;
+    float3 centerWorldPos = mul(_MatrixObjectToWorld, float4(pos, 1)).xyz;
     float4 centerClipPos = mul(UNITY_MATRIX_VP, float4(centerWorldPos, 1));
     centerClipPos.y *= -1;
+
     bool behindCam = centerClipPos.w <= 0;
-    if (behindCam)
-        return;
+    if (behindCam) return;
 
     float2 pixelPos = (centerClipPos.xy / centerClipPos.w * float2(0.5, -0.5) + 0.5) * _VecScreenParams.xy;
+
     if (pixelPos.x < _SelectionRect.x || pixelPos.x > _SelectionRect.z ||
         pixelPos.y < _SelectionRect.y || pixelPos.y > _SelectionRect.w)
     {
         return;
     }
+
     uint wordIdx = idx / 32;
     uint bitIdx = idx & 31;
+
     if (_SelectionMode)
         _SplatSelectedBits.InterlockedOr(wordIdx * 4, 1u << bitIdx); // +
     else
@@ -432,14 +569,12 @@ bool IsSplatSelected(uint idx)
     return (selVal & (1 << bitIdx)) != 0;
 }
 
-[numthreads(GROUP_SIZE,1,1)]
-void CSTranslateSelection (uint3 id : SV_DispatchThreadID)
+[numthreads(GROUP_SIZE, 1, 1)]
+void CSTranslateSelection(uint3 id : SV_DispatchThreadID)
 {
     uint idx = id.x;
-    if (idx >= _SplatCount)
-        return;
-    if (!IsSplatSelected(idx))
-        return;
+    if (idx >= _SplatCount) return;
+    if (!IsSplatSelected(idx)) return;
 
     uint fmt = _SplatFormat & 0xFF;
     if (_SplatChunkCount == 0 && fmt == VECTOR_FMT_32F)
@@ -456,14 +591,12 @@ float4 _SelectionDeltaRot;
 ByteAddressBuffer _SplatPosMouseDown;
 ByteAddressBuffer _SplatOtherMouseDown;
 
-[numthreads(GROUP_SIZE,1,1)]
-void CSRotateSelection (uint3 id : SV_DispatchThreadID)
+[numthreads(GROUP_SIZE, 1, 1)]
+void CSRotateSelection(uint3 id : SV_DispatchThreadID)
 {
     uint idx = id.x;
-    if (idx >= _SplatCount)
-        return;
-    if (!IsSplatSelected(idx))
-        return;
+    if (idx >= _SplatCount) return;
+    if (!IsSplatSelected(idx)) return;
 
     uint posFmt = _SplatFormat & 0xFF;
     if (_SplatChunkCount == 0 && posFmt == VECTOR_FMT_32F)
@@ -471,15 +604,16 @@ void CSRotateSelection (uint3 id : SV_DispatchThreadID)
         uint posStride = 12;
         float3 pos = asfloat(_SplatPosMouseDown.Load3(idx * posStride));
         pos -= _SelectionCenter;
-        pos = mul(_MatrixObjectToWorld, float4(pos,1)).xyz;
+        pos = mul(_MatrixObjectToWorld, float4(pos, 1)).xyz;
         pos = QuatRotateVector(pos, _SelectionDeltaRot);
-        pos = mul(_MatrixWorldToObject, float4(pos,1)).xyz;
+        pos = mul(_MatrixWorldToObject, float4(pos, 1)).xyz;
         pos += _SelectionCenter;
         _SplatPos.Store3(idx * posStride, asuint(pos));
     }
 
     uint scaleFmt = (_SplatFormat >> 8) & 0xFF;
     uint shFormat = (_SplatFormat >> 16) & 0xFF;
+
     if (_SplatChunkCount == 0 && scaleFmt == VECTOR_FMT_32F && shFormat == VECTOR_FMT_32F)
     {
         uint otherStride = 4 + 12;
@@ -488,7 +622,6 @@ void CSRotateSelection (uint3 id : SV_DispatchThreadID)
 
         //@TODO: correct rotation
         rot = QuatMul(rot, _SelectionDeltaRot);
-
         rotVal = EncodeQuatToNorm10(PackSmallest3Rotation(rot));
         _SplatOther.Store(idx * otherStride, rotVal);
     }
@@ -497,14 +630,13 @@ void CSRotateSelection (uint3 id : SV_DispatchThreadID)
 }
 
 //@TODO: maybe scale the splat scale itself too?
-[numthreads(GROUP_SIZE,1,1)]
-void CSScaleSelection (uint3 id : SV_DispatchThreadID)
+
+[numthreads(GROUP_SIZE, 1, 1)]
+void CSScaleSelection(uint3 id : SV_DispatchThreadID)
 {
     uint idx = id.x;
-    if (idx >= _SplatCount)
-        return;
-    if (!IsSplatSelected(idx))
-        return;
+    if (idx >= _SplatCount) return;
+    if (!IsSplatSelected(idx)) return;
 
     uint fmt = _SplatFormat & 0xFF;
     if (_SplatChunkCount == 0 && fmt == VECTOR_FMT_32F)
@@ -512,9 +644,9 @@ void CSScaleSelection (uint3 id : SV_DispatchThreadID)
         uint stride = 12;
         float3 pos = asfloat(_SplatPosMouseDown.Load3(idx * stride));
         pos -= _SelectionCenter;
-        pos = mul(_MatrixObjectToWorld, float4(pos,1)).xyz;
+        pos = mul(_MatrixObjectToWorld, float4(pos, 1)).xyz;
         pos *= _SelectionDelta;
-        pos = mul(_MatrixWorldToObject, float4(pos,1)).xyz;
+        pos = mul(_MatrixWorldToObject, float4(pos, 1)).xyz;
         pos += _SelectionCenter;
         _SplatPos.Store3(idx * stride, asuint(pos));
     }
@@ -525,23 +657,28 @@ struct ExportSplatData
     float3 pos;
     float3 nor;
     float3 dc0;
-    float4 shR14; float4 shR58; float4 shR9C; float3 shRDF;
-    float4 shG14; float4 shG58; float4 shG9C; float3 shGDF;
-    float4 shB14; float4 shB58; float4 shB9C; float3 shBDF;
+    float4 shR14;
+    float4 shR58;
+    float4 shR9C;
+    float3 shRDF;
+    float4 shG14;
+    float4 shG58;
+    float4 shG9C;
+    float3 shGDF;
+    float4 shB14;
+    float4 shB58;
+    float4 shB9C;
+    float3 shBDF;
     float opacity;
     float3 scale;
     float4 rot;
 };
+
 RWStructuredBuffer<ExportSplatData> _ExportBuffer;
 
-float3 ColorToSH0(float3 col)
-{
-    return (col - 0.5) / 0.2820948;
-}
-float InvSigmoid(float v)
-{
-    return log(v / max(1 - v, 1.0e-6));
-}
+float3 ColorToSH0(float3 col) { return (col - 0.5) / 0.2820948; }
+
+float InvSigmoid(float v) { return log(v / max(1 - v, 1.0e-6)); }
 
 // SH rotation
 #include "SphericalHarmonics.hlsl"
@@ -550,6 +687,7 @@ void RotateSH(inout SplatSHData sh, float3x3 rot)
 {
     float3 shin[16];
     float3 shout[16];
+
     shin[0] = sh.col;
     shin[1] = sh.sh1;
     shin[2] = sh.sh2;
@@ -566,7 +704,9 @@ void RotateSH(inout SplatSHData sh, float3x3 rot)
     shin[13] = sh.sh13;
     shin[14] = sh.sh14;
     shin[15] = sh.sh15;
+
     RotateSH(rot, 4, shin, shout);
+
     sh.col = shout[0];
     sh.sh1 = shout[1];
     sh.sh2 = shout[2];
@@ -588,6 +728,7 @@ void RotateSH(inout SplatSHData sh, float3x3 rot)
 float3x3 CalcSHRotMatrix(float4x4 objToWorld)
 {
     float3x3 m = (float3x3)objToWorld;
+
     float sx = length(float3(m[0][0], m[0][1], m[0][2]));
     float sy = length(float3(m[1][0], m[1][1], m[1][2]));
     float sz = length(float3(m[2][0], m[2][1], m[2][2]));
@@ -596,45 +737,36 @@ float3x3 CalcSHRotMatrix(float4x4 objToWorld)
     float invSY = 1.0 / sy;
     float invSZ = 1.0 / sz;
 
-    m[0][0] *= invSX;
-    m[0][1] *= invSX;
-    m[0][2] *= invSX;
-    m[1][0] *= invSY;
-    m[1][1] *= invSY;
-    m[1][2] *= invSY;
-    m[2][0] *= invSZ;
-    m[2][1] *= invSZ;
-    m[2][2] *= invSZ;
+    m[0][0] *= invSX; m[0][1] *= invSX; m[0][2] *= invSX;
+    m[1][0] *= invSY; m[1][1] *= invSY; m[1][2] *= invSY;
+    m[2][0] *= invSZ; m[2][1] *= invSZ; m[2][2] *= invSZ;
+
     return m;
 }
-
 
 float4 _ExportTransformRotation;
 float3 _ExportTransformScale;
 uint _ExportTransformFlags;
 
-[numthreads(GROUP_SIZE,1,1)]
-void CSExportData (uint3 id : SV_DispatchThreadID)
+[numthreads(GROUP_SIZE, 1, 1)]
+void CSExportData(uint3 id : SV_DispatchThreadID)
 {
     uint idx = id.x;
-    if (idx >= _SplatCount)
-        return;
-    SplatData src = LoadSplatData(idx);
+    if (idx >= _SplatCount) return;
 
+    SplatData src = LoadSplatData(idx);
     bool isCut = IsSplatCut(src.pos);
 
     // transform splat by matrix, if needed
     if (_ExportTransformFlags != 0)
     {
-        src.pos = mul(_MatrixObjectToWorld, float4(src.pos,1)).xyz;
+        src.pos = mul(_MatrixObjectToWorld, float4(src.pos, 1)).xyz;
 
         // note: this only handles axis flips from scale, not any arbitrary scaling
-        if (_ExportTransformScale.x < 0)
-            src.rot.yz = -src.rot.yz;
-        if (_ExportTransformScale.y < 0)
-            src.rot.xz = -src.rot.xz;
-        if (_ExportTransformScale.z < 0)
-            src.rot.xy = -src.rot.xy;
+        if (_ExportTransformScale.x < 0) src.rot.yz = -src.rot.yz;
+        if (_ExportTransformScale.y < 0) src.rot.xz = -src.rot.xz;
+        if (_ExportTransformScale.z < 0) src.rot.xy = -src.rot.xy;
+
         src.rot = QuatMul(_ExportTransformRotation, src.rot);
         src.scale *= abs(_ExportTransformScale);
 
@@ -646,29 +778,28 @@ void CSExportData (uint3 id : SV_DispatchThreadID)
     dst.pos = src.pos;
     dst.nor = 0;
     dst.dc0 = ColorToSH0(src.sh.col);
-    
+
     dst.shR14 = float4(src.sh.sh1.r, src.sh.sh2.r, src.sh.sh3.r, src.sh.sh4.r);
     dst.shR58 = float4(src.sh.sh5.r, src.sh.sh6.r, src.sh.sh7.r, src.sh.sh8.r);
     dst.shR9C = float4(src.sh.sh9.r, src.sh.sh10.r, src.sh.sh11.r, src.sh.sh12.r);
     dst.shRDF = float3(src.sh.sh13.r, src.sh.sh14.r, src.sh.sh15.r);
-    
+
     dst.shG14 = float4(src.sh.sh1.g, src.sh.sh2.g, src.sh.sh3.g, src.sh.sh4.g);
     dst.shG58 = float4(src.sh.sh5.g, src.sh.sh6.g, src.sh.sh7.g, src.sh.sh8.g);
     dst.shG9C = float4(src.sh.sh9.g, src.sh.sh10.g, src.sh.sh11.g, src.sh.sh12.g);
     dst.shGDF = float3(src.sh.sh13.g, src.sh.sh14.g, src.sh.sh15.g);
-    
+
     dst.shB14 = float4(src.sh.sh1.b, src.sh.sh2.b, src.sh.sh3.b, src.sh.sh4.b);
     dst.shB58 = float4(src.sh.sh5.b, src.sh.sh6.b, src.sh.sh7.b, src.sh.sh8.b);
     dst.shB9C = float4(src.sh.sh9.b, src.sh.sh10.b, src.sh.sh11.b, src.sh.sh12.b);
     dst.shBDF = float3(src.sh.sh13.b, src.sh.sh14.b, src.sh.sh15.b);
-    
+
     dst.opacity = InvSigmoid(src.opacity);
     dst.scale = log(src.scale);
     dst.rot = src.rot.wxyz;
 
-    if (isCut)
-        dst.nor = 1; // mark as skipped for export
-    
+    if (isCut) dst.nor = 1; // mark as skipped for export
+
     _ExportBuffer[idx] = dst;
 }
 
@@ -677,34 +808,33 @@ RWByteAddressBuffer _CopyDstOther;
 RWByteAddressBuffer _CopyDstSH;
 RWByteAddressBuffer _CopyDstEditDeleted;
 RWTexture2D<float4> _CopyDstColor;
-uint _CopyDstSize, _CopySrcStartIndex, _CopyDstStartIndex, _CopyCount;
 
+uint _CopyDstSize, _CopySrcStartIndex, _CopyDstStartIndex, _CopyCount;
 float4x4 _CopyTransformMatrix;
 float4 _CopyTransformRotation;
 float3 _CopyTransformScale;
 
-[numthreads(GROUP_SIZE,1,1)]
-void CSCopySplats (uint3 id : SV_DispatchThreadID)
+[numthreads(GROUP_SIZE, 1, 1)]
+void CSCopySplats(uint3 id : SV_DispatchThreadID)
 {
     uint idx = id.x;
-    if (idx >= _CopyCount)
-        return;
+    if (idx >= _CopyCount) return;
+
     uint srcIdx = _CopySrcStartIndex + idx;
     uint dstIdx = _CopyDstStartIndex + idx;
-    if (srcIdx >= _SplatCount || dstIdx >= _CopyDstSize)
-        return;
+
+    if (srcIdx >= _SplatCount || dstIdx >= _CopyDstSize) return;
 
     SplatData src = LoadSplatData(idx);
 
     // transform the splat
-    src.pos = mul(_CopyTransformMatrix, float4(src.pos,1)).xyz;
+    src.pos = mul(_CopyTransformMatrix, float4(src.pos, 1)).xyz;
+
     // note: this only handles axis flips from scale, not any arbitrary scaling
-    if (_CopyTransformScale.x < 0)
-        src.rot.yz = -src.rot.yz;
-    if (_CopyTransformScale.y < 0)
-        src.rot.xz = -src.rot.xz;
-    if (_CopyTransformScale.z < 0)
-        src.rot.xy = -src.rot.xy;
+    if (_CopyTransformScale.x < 0) src.rot.yz = -src.rot.yz;
+    if (_CopyTransformScale.y < 0) src.rot.xz = -src.rot.xz;
+    if (_CopyTransformScale.z < 0) src.rot.xy = -src.rot.xy;
+
     src.rot = QuatMul(_CopyTransformRotation, src.rot);
     src.scale *= abs(_CopyTransformScale);
 
@@ -715,14 +845,14 @@ void CSCopySplats (uint3 id : SV_DispatchThreadID)
     // pos
     uint posStride = 12;
     _CopyDstPos.Store3(dstIdx * posStride, asuint(src.pos));
+
     // rot + scale
     uint otherStride = 4 + 12;
     uint rotVal = EncodeQuatToNorm10(PackSmallest3Rotation(src.rot));
-    _CopyDstOther.Store4(dstIdx * otherStride, uint4(
-        rotVal,
-        asuint(src.scale.x),
-        asuint(src.scale.y),
-        asuint(src.scale.z)));
+    _CopyDstOther.Store4(
+        dstIdx * otherStride,
+        uint4(rotVal, asuint(src.scale.x), asuint(src.scale.y), asuint(src.scale.z)));
+
     // color
     uint3 pixelIndex = SplatIndexToPixelIndex(dstIdx);
     _CopyDstColor[pixelIndex.xy] = float4(src.sh.col, src.opacity);
@@ -730,6 +860,7 @@ void CSCopySplats (uint3 id : SV_DispatchThreadID)
     // SH
     uint shStride = 192; // 15*3 fp32, rounded up to multiple of 16
     uint shOffset = dstIdx * shStride;
+
     _CopyDstSH.Store3(shOffset + 12 * 0, asuint(src.sh.sh1));
     _CopyDstSH.Store3(shOffset + 12 * 1, asuint(src.sh.sh2));
     _CopyDstSH.Store3(shOffset + 12 * 2, asuint(src.sh.sh3));

--- a/package/Shaders/SplatUtilities.compute
+++ b/package/Shaders/SplatUtilities.compute
@@ -32,6 +32,8 @@
 #pragma kernel Upsweep
 #pragma kernel Scan
 #pragma kernel Downsweep
+#pragma kernel BuildIndirectArgs
+//#pragma kernel ClearPassHist
 
 // GPU sorting needs wave ops
 #pragma require wavebasic


### PR DESCRIPTION
Hi,

this is an implementation of frustum culling for the plugin. It basically follows [Aras's post](https://github.com/aras-p/UnityGaussianSplatting/issues/49).

- Mainly I added a kernel ( CSCullFrustum ) that finds splats outside the frustum of the camera and culls them.
- It also takes into account splats with centers outside the frustum that still appear inside it by calculating a conservative scale value.
- It rewrites visible splats into the sort key buffer and writes the count into a new buffer that will be passed to following kernels indirectly.
- I had to change the order of the kernels so the CalcView is done before sorting. The reason is since I'm reusing the sort key buffer to store the remaining splats, if I use CalcView after sorting the splats the latency of pulling sorted splats is very high due to memory locality and it impacts the performance. Thankfully, CalcView doesn't depend on sorting kernel so it doesn't impact the results.

These are the main changes. However, since the key buffer is dynamic now I had to change a lot of the code to support indirect dispatching/drawing.

Results:

It is hard to quantify the uplift but I do currently get +20-50% performance in a room scene (2.4M + 200k splats with quality "very high") based on the angle I'm looking at. Obviously the less splats on camera the more the performance. For worst-case scenario I placed the camera outside the room looking at the entire splat and it seems to generally have the same performance. Tested on a 3080 12G. It worked also on an intel ultra 5 235u integrated graphics.