### PR TITLE
Support creating assets from PLY files larger than 2GB

### DIFF
--- a/package/Editor/GaussianSplatAssetCreator.cs
+++ b/package/Editor/GaussianSplatAssetCreator.cs
@@ -408,7 +408,7 @@ namespace GaussianSplatting.Editor
             }
         }
 
-        static void ReorderMorton(NativeArray<InputSplatData> splatData, float3 boundsMin, float3 boundsMax)
+        static unsafe void ReorderMorton(NativeArray<InputSplatData> splatData, float3 boundsMin, float3 boundsMax)
         {
             ReorderMortonJob order = new ReorderMortonJob
             {
@@ -420,9 +420,17 @@ namespace GaussianSplatting.Editor
             order.Schedule(splatData.Length, 4096).Complete();
             order.m_Order.Sort(new OrderComparer());
 
-            NativeArray<InputSplatData> copy = new(order.m_SplatData, Allocator.TempJob);
+            // Copy the source data, then gather it back in the new order. Use an explicit long-sized MemCpy
+            // instead of the NativeArray copy constructor / NativeArray.Copy: their internal size is computed as
+            // 'length * sizeof' in int, which overflows once the array exceeds 2GB (>8.6M splats * 248 bytes) and
+            // crashes inside memcpy.
+            NativeArray<InputSplatData> copy = new(splatData.Length, Allocator.TempJob, NativeArrayOptions.UninitializedMemory);
+            UnsafeUtility.MemCpy(copy.GetUnsafePtr(), splatData.GetUnsafeReadOnlyPtr(),
+                (long)splatData.Length * UnsafeUtility.SizeOf<InputSplatData>());
+            InputSplatData* copyPtr = (InputSplatData*)copy.GetUnsafeReadOnlyPtr();
+            InputSplatData* dstPtr = (InputSplatData*)splatData.GetUnsafePtr();
             for (int i = 0; i < copy.Length; ++i)
-                order.m_SplatData[i] = copy[order.m_Order[i].Item2];
+                dstPtr[i] = copyPtr[order.m_Order[i].Item2];
             copy.Dispose();
 
             order.m_Order.Dispose();

--- a/package/Editor/Utils/GaussianFileReader.cs
+++ b/package/Editor/Utils/GaussianFileReader.cs
@@ -76,7 +76,7 @@ namespace GaussianSplatting.Editor.Utils
             NativeArray<byte> rawBatch = new(batchSplats * vertexStride, Allocator.Persistent);
             try
             {
-                byte* dstBase = (byte*)splats.GetUnsafePtr();
+                InputSplatData* dstBase = (InputSplatData*)splats.GetUnsafePtr();
                 int* srcOffPtr = (int*)srcOffsets.GetUnsafeReadOnlyPtr();
                 byte* rawPtr = (byte*)rawBatch.GetUnsafeReadOnlyPtr();
 
@@ -91,7 +91,7 @@ namespace GaussianSplatting.Editor.Utils
                     new ReorderPLYDataJob
                     {
                         src = rawPtr,
-                        dst = dstBase + (long)splatIndex * dstStride,
+                        dst = (byte*)(dstBase + splatIndex),
                         srcOffsets = srcOffPtr,
                         srcStride = vertexStride,
                         dstStride = dstStride,
@@ -99,15 +99,22 @@ namespace GaussianSplatting.Editor.Utils
                     }.Schedule(thisBatch, 8192).Complete();
                     splatIndex += thisBatch;
                 }
+
+                ReorderSHs(splatCount, (float*)splats.GetUnsafePtr());
+                LinearizeData(splats);
+            }
+            catch
+            {
+                // Don't leak the (potentially multi-GB) destination array if reading or converting fails partway.
+                splats.Dispose();
+                splats = default;
+                throw;
             }
             finally
             {
                 rawBatch.Dispose();
                 srcOffsets.Dispose();
             }
-
-            ReorderSHs(splatCount, (float*)splats.GetUnsafePtr());
-            LinearizeData(splats);
         }
 
         // Reads exactly 'count' bytes from the stream into the start of 'buffer' (Stream.Read may return short reads).

--- a/package/Editor/Utils/GaussianFileReader.cs
+++ b/package/Editor/Utils/GaussianFileReader.cs
@@ -88,7 +88,15 @@ namespace GaussianSplatting.Editor.Utils
                     int got = ReadExactly(fs, rawBatch, bytesToRead);
                     if (got != bytesToRead)
                         throw new IOException($"PLY {filePath} read error, expected {bytesToRead} data bytes got {got}");
-                    ReorderPLYData(thisBatch, rawPtr, vertexStride, dstBase + (long)splatIndex * dstStride, dstStride, srcOffPtr);
+                    new ReorderPLYDataJob
+                    {
+                        src = rawPtr,
+                        dst = dstBase + (long)splatIndex * dstStride,
+                        srcOffsets = srcOffPtr,
+                        srcStride = vertexStride,
+                        dstStride = dstStride,
+                        attrCount = dstStride / 4
+                    }.Schedule(thisBatch, 8192).Complete();
                     splatIndex += thisBatch;
                 }
             }
@@ -219,18 +227,28 @@ namespace GaussianSplatting.Editor.Utils
             return srcOffsets;
         }
 
+        // Scatters one batch of raw PLY vertex records into InputSplatData layout. Implemented as a regular Burst
+        // job (not a [BurstCompile] static direct-call) so it always uses Burst's standard, synchronously-available
+        // job compilation path instead of the function-pointer path, which can fail to compile in time on first use.
         [BurstCompile]
-        static unsafe void ReorderPLYData(int splatCount, byte* src, int srcStride, byte* dst, int dstStride, int* srcOffsets)
+        struct ReorderPLYDataJob : IJobParallelFor
         {
-            for (int i = 0; i < splatCount; i++)
+            [NativeDisableUnsafePtrRestriction] public unsafe byte* src;
+            [NativeDisableUnsafePtrRestriction] public unsafe byte* dst;
+            [NativeDisableUnsafePtrRestriction] public unsafe int* srcOffsets;
+            public int srcStride;
+            public int dstStride;
+            public int attrCount;
+
+            public unsafe void Execute(int i)
             {
-                for (int attr = 0; attr < dstStride / 4; attr++)
+                byte* s = src + (long)i * srcStride;
+                byte* d = dst + (long)i * dstStride;
+                for (int attr = 0; attr < attrCount; attr++)
                 {
                     if (srcOffsets[attr] >= 0)
-                        *(int*)(dst + attr * 4) = *(int*)(src + srcOffsets[attr]);
+                        *(int*)(d + attr * 4) = *(int*)(s + srcOffsets[attr]);
                 }
-                src += srcStride;
-                dst += dstStride;
             }
         }
 

--- a/package/Editor/Utils/GaussianFileReader.cs
+++ b/package/Editor/Utils/GaussianFileReader.cs
@@ -46,15 +46,7 @@ namespace GaussianSplatting.Editor.Utils
         {
             if (isPLY(filePath))
             {
-                NativeArray<byte> plyRawData;
-                List<(string, PLYFileReader.ElementType)> attributes;
-                PLYFileReader.ReadFile(filePath, out var splatCount, out var vertexStride, out attributes, out plyRawData);
-                string attrError = CheckPLYAttributes(attributes);
-                if (!string.IsNullOrEmpty(attrError))
-                    throw new IOException($"PLY file is probably not a Gaussian Splat file? Missing properties: {attrError}");
-                splats = PLYDataToSplats(plyRawData, splatCount, vertexStride, attributes);
-                ReorderSHs(splatCount, (float*)splats.GetUnsafePtr());
-                LinearizeData(splats);
+                ReadPLYFile(filePath, out splats);
                 return;
             }
             if (isSPZ(filePath))
@@ -63,6 +55,65 @@ namespace GaussianSplatting.Editor.Utils
                 return;
             }
             throw new IOException($"File {filePath} is not a supported format");
+        }
+
+        static unsafe void ReadPLYFile(string filePath, out NativeArray<InputSplatData> splats)
+        {
+            using var fs = PLYFileReader.OpenAndReadHeader(filePath, out var splatCount, out var vertexStride, out var attributes);
+            string attrError = CheckPLYAttributes(attributes);
+            if (!string.IsNullOrEmpty(attrError))
+                throw new IOException($"PLY file is probably not a Gaussian Splat file? Missing properties: {attrError}");
+
+            // The destination splat array can be larger than 2GB in total (its element count still fits in an int),
+            // but the raw PLY body can exceed the ~2GB NativeArray<byte> size limit. So read the body in batches into
+            // a small reusable buffer and convert each batch straight into the destination array.
+            NativeArray<int> srcOffsets = BuildSrcOffsets(attributes);
+            int dstStride = UnsafeUtility.SizeOf<InputSplatData>();
+            splats = new NativeArray<InputSplatData>(splatCount, Allocator.Persistent);
+
+            const int kBatchSplats = 1024 * 1024;
+            int batchSplats = math.min(kBatchSplats, math.max(1, splatCount));
+            NativeArray<byte> rawBatch = new(batchSplats * vertexStride, Allocator.Persistent);
+            try
+            {
+                byte* dstBase = (byte*)splats.GetUnsafePtr();
+                int* srcOffPtr = (int*)srcOffsets.GetUnsafeReadOnlyPtr();
+                byte* rawPtr = (byte*)rawBatch.GetUnsafeReadOnlyPtr();
+
+                int splatIndex = 0;
+                while (splatIndex < splatCount)
+                {
+                    int thisBatch = math.min(batchSplats, splatCount - splatIndex);
+                    int bytesToRead = thisBatch * vertexStride;
+                    int got = ReadExactly(fs, rawBatch, bytesToRead);
+                    if (got != bytesToRead)
+                        throw new IOException($"PLY {filePath} read error, expected {bytesToRead} data bytes got {got}");
+                    ReorderPLYData(thisBatch, rawPtr, vertexStride, dstBase + (long)splatIndex * dstStride, dstStride, srcOffPtr);
+                    splatIndex += thisBatch;
+                }
+            }
+            finally
+            {
+                rawBatch.Dispose();
+                srcOffsets.Dispose();
+            }
+
+            ReorderSHs(splatCount, (float*)splats.GetUnsafePtr());
+            LinearizeData(splats);
+        }
+
+        // Reads exactly 'count' bytes from the stream into the start of 'buffer' (Stream.Read may return short reads).
+        static int ReadExactly(Stream fs, NativeArray<byte> buffer, int count)
+        {
+            int total = 0;
+            while (total < count)
+            {
+                int n = fs.Read(buffer.GetSubArray(total, count - total));
+                if (n <= 0)
+                    break;
+                total += n;
+            }
+            return total;
         }
 
         static bool isPLY(string filePath) => filePath.EndsWith(".ply", true, CultureInfo.InvariantCulture);
@@ -77,7 +128,9 @@ namespace GaussianSplatting.Editor.Utils
             return string.Join(",", missing);
         }
 
-        static unsafe NativeArray<InputSplatData> PLYDataToSplats(NativeArray<byte> input, int count, int stride, List<(string, PLYFileReader.ElementType)> attributes)
+        // Builds, for each float field of InputSplatData, the byte offset of the matching attribute inside a PLY
+        // vertex record (or -1 if the attribute is absent). Returned array is Persistent; caller disposes it.
+        static NativeArray<int> BuildSrcOffsets(List<(string, PLYFileReader.ElementType)> attributes)
         {
             NativeArray<int> fileAttrOffsets = new NativeArray<int>(attributes.Count, Allocator.Temp);
             int offset = 0;
@@ -154,17 +207,16 @@ namespace GaussianSplatting.Editor.Utils
                 "rot_3",                
             };
             Assert.AreEqual(UnsafeUtility.SizeOf<InputSplatData>() / 4, splatAttributes.Length);
-            NativeArray<int> srcOffsets = new NativeArray<int>(splatAttributes.Length, Allocator.Temp);
+            NativeArray<int> srcOffsets = new NativeArray<int>(splatAttributes.Length, Allocator.Persistent);
             for (int ai = 0; ai < splatAttributes.Length; ai++)
             {
                 int attrIndex = attributes.IndexOf((splatAttributes[ai], PLYFileReader.ElementType.Float));
                 int attrOffset = attrIndex >= 0 ? fileAttrOffsets[attrIndex] : -1;
                 srcOffsets[ai] = attrOffset;
             }
-            
-            NativeArray<InputSplatData> dst = new NativeArray<InputSplatData>(count, Allocator.Persistent);
-            ReorderPLYData(count, (byte*)input.GetUnsafeReadOnlyPtr(), stride, (byte*)dst.GetUnsafePtr(), UnsafeUtility.SizeOf<InputSplatData>(), (int*)srcOffsets.GetUnsafeReadOnlyPtr());
-            return dst;
+
+            fileAttrOffsets.Dispose();
+            return srcOffsets;
         }
 
         [BurstCompile]

--- a/package/Editor/Utils/PLYFileReader.cs
+++ b/package/Editor/Utils/PLYFileReader.cs
@@ -5,7 +5,6 @@ using System.Collections.Generic;
 using System.IO;
 using System.Linq;
 using System.Text;
-using Unity.Collections;
 
 namespace GaussianSplatting.Editor.Utils
 {
@@ -22,12 +21,26 @@ namespace GaussianSplatting.Editor.Utils
             ReadHeaderImpl(filePath, out vertexCount, out vertexStride, out attrs, fs);
         }
 
+        // Opens the file, parses the header, and returns the stream positioned at the start of the binary
+        // vertex data. The body is meant to be read in batches, so files larger than 2GB are supported.
+        // Caller is responsible for disposing the returned stream.
+        public static FileStream OpenAndReadHeader(string filePath, out int vertexCount, out int vertexStride, out List<(string, ElementType)> attrs)
+        {
+            var fs = new FileStream(filePath, FileMode.Open, FileAccess.Read);
+            try
+            {
+                ReadHeaderImpl(filePath, out vertexCount, out vertexStride, out attrs, fs);
+            }
+            catch
+            {
+                fs.Dispose();
+                throw;
+            }
+            return fs;
+        }
+
         static void ReadHeaderImpl(string filePath, out int vertexCount, out int vertexStride, out List<(string, ElementType)> attrs, FileStream fs)
         {
-            // C# arrays and NativeArrays make it hard to have a "byte" array larger than 2GB :/
-            if (fs.Length >= 2 * 1024 * 1024 * 1024L)
-                throw new IOException($"PLY {filePath} read error: currently files larger than 2GB are not supported");
-
             // read header
             vertexCount = 0;
             vertexStride = 0;
@@ -62,17 +75,6 @@ namespace GaussianSplatting.Editor.Utils
             {
                 throw new IOException($"PLY {filePath} not supported: needs to be binary, little endian PLY format");
             }
-        }
-
-        public static void ReadFile(string filePath, out int vertexCount, out int vertexStride, out List<(string, ElementType)> attrs, out NativeArray<byte> vertices)
-        {
-            using var fs = new FileStream(filePath, FileMode.Open, FileAccess.Read);
-            ReadHeaderImpl(filePath, out vertexCount, out vertexStride, out attrs, fs);
-
-            vertices = new NativeArray<byte>(vertexCount * vertexStride, Allocator.Persistent);
-            var readBytes = fs.Read(vertices);
-            if (readBytes != vertices.Length)
-                throw new IOException($"PLY {filePath} read error, expected {vertices.Length} data bytes got {readBytes}");
         }
 
         public enum ElementType


### PR DESCRIPTION
## Problem

Creating a `GaussianSplatAsset` from a large PLY file (2.38 GB, ~10.3M splats, full SH) failed — first with a `files larger than 2GB are not supported` error, and after lifting that check, with a hard Editor crash inside `memcpy`.

Both issues come from size calculations done in `int` that overflow once a per-splat buffer exceeds 2GB (`InputSplatData` is a fixed 248 bytes/splat, so 8.6M splats ≈ 2GB).

## Fix

- **`PLYFileReader`**: previously loaded the entire binary body into one `NativeArray<byte>` (capped at ~2GB) and rejected larger files outright. Now opens the stream positioned at the body via `OpenAndReadHeader` and reads it in 1M-splat batches straight into the destination `InputSplatData` array (whose element count still fits in an `int`, so >2GB total is fine).
- **`ReorderMorton`**: duplicated the splat array via the `NativeArray` copy constructor, whose internal size is `length * sizeof` computed in `int` — this overflows past 2GB and crashes inside `memcpy`. Replaced with an explicit `long`-sized `UnsafeUtility.MemCpy` and a pointer-based gather.

## Notes / scope

- This enables import and rendering of >8.6M-splat clouds. Editing (Edit/Resize) and `Export PLY` remain bounded by the existing `kMaxSplats = 8.6M` limit and are out of scope here.
- Tested manually in the Editor with a 2.38 GB / 10.3M-splat PLY at High quality.